### PR TITLE
fix: name the precipitation probability sensor, fix Italian pressure typo

### DIFF
--- a/custom_components/arpa_veneto_weather/translations/en.json
+++ b/custom_components/arpa_veneto_weather/translations/en.json
@@ -90,6 +90,9 @@
             "precipitation": {
                 "name": "Precipitation (last 5 minutes) in {station_name}"
             },
+            "precipitation_probability": {
+                "name": "Precipitation probability in {station_name}"
+            },
             "precipitation_hourly": {
                 "name": "Precipitation intensity in {station_name}"
             },

--- a/custom_components/arpa_veneto_weather/translations/it.json
+++ b/custom_components/arpa_veneto_weather/translations/it.json
@@ -88,6 +88,9 @@
             "precipitation": {
                 "name": "Precipitazioni ultimi 5 minuti  a {station_name}"
             },
+            "precipitation_probability": {
+                "name": "Probabilità di precipitazione a {station_name}"
+            },
             "precipitation_hourly": {
                 "name": "Intensità precipitazioni a {station_name}"
             },
@@ -110,7 +113,7 @@
                 "name": "Precipitazioni cumulative ultime 24h a {station_name}"
             },
             "pressure": {
-                "name": "Pressionre a {station_name}"
+                "name": "Pressione a {station_name}"
             },
             "wind_bearing": {
                 "name": "Direzione vento a {station_name}"


### PR DESCRIPTION
## Problem

The precipitation probability sensor ships without a name: it ends up as
`sensor.arpa_veneto_weather`, with friendly name "Arpa Veneto Weather" —
indistinguishable from the device itself.

Two causes combine:

- `precipitation_probability` is missing from `entity.sensor` in both `en.json`
  and `it.json`;
- its `device_class` is `probability`, which is not a member of
  `SensorDeviceClass` (checked against core 2026.8.2), so Home Assistant cannot
  derive a name from it either.

With `_attr_has_entity_name = True` and neither source available, the entity
inherits only the device name.

`pm10`, `pm25` and `ozone` are missing from the translations too, but they are
saved by their valid device classes, from which HA derives "PM10", "PM2.5" and
"Ozone" — left untouched on purpose, so existing friendly names don't change.

## Changes

- add the `precipitation_probability` name in `en.json` and `it.json`, using the
  same `{station_name}` placeholder as the other sensors;
- fix the Italian pressure typo: `Pressionre a {station_name}` →
  `Pressione a {station_name}`.

## Note

Both changes affect friendly names only. Entity IDs already generated keep their
previous form (`sensor.arpa_veneto_weather`,
`sensor.arpa_veneto_weather_pressionre_...`) unless renamed manually, so it may
be worth a changelog line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
