### PR TITLE
fix: use valid sensor device classes, add icons

### DIFF
--- a/custom_components/arpa_veneto_weather/const.py
+++ b/custom_components/arpa_veneto_weather/const.py
@@ -45,7 +45,7 @@ SENSOR_TYPES = {
     "visibility": {
         "name": "Visibility",
         "unit": "km",
-        "device_class": "visibility",
+        "device_class": "distance",
         "state_class": "measurement",
     },
     "precipitation": {
@@ -57,13 +57,12 @@ SENSOR_TYPES = {
     "precipitation_probability": {
         "name": "Precipitation probability",
         "unit": "%",
-        "device_class": "probability",
         "state_class": "measurement",
     },
     "precipitation_hourly": {
         "name": "Precipitation intensity (mm/h)",
         "unit": "mm/h",
-        "device_class": "precipitation",
+        "device_class": "precipitation_intensity",
         "state_class": "total_increasing",
     },
     "precipitation_cumulative_1h": {
@@ -110,19 +109,16 @@ SENSOR_TYPES = {
     },
     "wind_bearing": {
         "name": "Wind bearing",
-        "device_class": "direction",
-        "state_class": "measurement",
     },
     "wind_speed": {
         "name": "Wind speed",
         "unit": "km/h",
-        "device_class": "wind",
+        "device_class": "wind_speed",
         "state_class": "measurement",
     },
     "uv_index": {
         "name": "UV index",
         "unit": "UV index",
-        "device_class": "uv_index",
         "state_class": "measurement",
     },
     "pm10": {

--- a/custom_components/arpa_veneto_weather/icons.json
+++ b/custom_components/arpa_veneto_weather/icons.json
@@ -1,0 +1,21 @@
+{
+    "entity": {
+        "sensor": {
+            "visibility": {
+                "default": "mdi:eye"
+            },
+            "precipitation_probability": {
+                "default": "mdi:weather-rainy"
+            },
+            "precipitation_hourly": {
+                "default": "mdi:weather-pouring"
+            },
+            "wind_bearing": {
+                "default": "mdi:compass-outline"
+            },
+            "uv_index": {
+                "default": "mdi:sun-wireless"
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Problem

Checked against `SensorDeviceClass` in core 2026.8.2: five of the declared device
classes are not members of the enum, so those entities get no derived icon and no
unit handling.

| sensor | declared | valid? | changed to |
|---|---|---|---|
| `visibility` | `visibility` | no | `distance` |
| `precipitation_probability` | `probability` | no | none |
| `wind_bearing` | `direction` | no | none |
| `wind_speed` | `wind` | no | `wind_speed` |
| `uv_index` | `uv_index` | no | none |
| `precipitation_hourly` | `precipitation` | wrong unit class | `precipitation_intensity` |

`wind_bearing` also declared `state_class: measurement` while its state is a
cardinal string (`ENE`), which the recorder cannot aggregate — dropped. The
coordinator already computes `native_wind_bearing` in degrees, so exposing the
numeric value under `wind_direction` would be possible, but that changes the
state format, so I left it out of this fix.

The integration also ships no `icons.json` and never sets `_attr_icon`, so every
icon comes from the device class. Added one for the sensors that now have no
suitable class:

- `visibility` → `mdi:eye`
- `precipitation_probability` → `mdi:weather-rainy`
- `precipitation_hourly` → `mdi:weather-pouring`
- `wind_bearing` → `mdi:compass-outline`
- `uv_index` → `mdi:sun-wireless`

Sensors with a valid device class keep their automatic icon.

## Testing

Running on HA 2026.8.2 with a station in Sant'Elena (Padova). After restart the
entities report the new classes (`distance`, `precipitation_intensity`,
`wind_speed`, and no class where none applies), and `frontend/get_icons` for
`arpa_veneto_weather` returns all five icons, so the frontend picks them up. No
warnings in the log.

Entity IDs are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
