### PR TITLE
feat: add leaf wetness sensor

### DIFF
--- a/custom_components/arpa_veneto_weather/const.py
+++ b/custom_components/arpa_veneto_weather/const.py
@@ -125,6 +125,12 @@ SENSOR_TYPES = {
         "device_class": "uv_index",
         "state_class": "measurement",
     },
+    "leaf_wetness": {
+        "name": "Leaf wetness",
+        "unit": "%",
+        "device_class": "moisture",
+        "state_class": "measurement",
+    },
     "pm10": {
         "name": "PM10",
         "unit": "µg/m³",

--- a/custom_components/arpa_veneto_weather/coordinator.py
+++ b/custom_components/arpa_veneto_weather/coordinator.py
@@ -168,6 +168,9 @@ class ArpaVenetoDataUpdateCoordinator(DataUpdateCoordinator):
                     # For W/m², the scaling factor is 0.04 because it represents instantaneous power
                     extracted_data["uv_index"] = round(float(valore) * 0.06 * 0.04)
                     extracted_data["ghi"] = round(float(valore))
+            elif tipo == "BFOGL":
+                # Leaf wetness, reported as the share of the interval the leaf was wet
+                extracted_data["leaf_wetness"] = float(valore)
 
         # prepare additional precipitation metrics
         # given that

--- a/custom_components/arpa_veneto_weather/translations/en.json
+++ b/custom_components/arpa_veneto_weather/translations/en.json
@@ -122,6 +122,9 @@
             },
             "uv_index": {
                 "name": "UV index in {station_name}"
+            },
+            "leaf_wetness": {
+                "name": "Leaf wetness in {station_name}"
             }
         },
         "weather": {

--- a/custom_components/arpa_veneto_weather/translations/it.json
+++ b/custom_components/arpa_veneto_weather/translations/it.json
@@ -120,6 +120,9 @@
             },
             "uv_index": {
                 "name": "Indice UV a {station_name}"
+            },
+            "leaf_wetness": {
+                "name": "Bagnatura fogliare a {station_name}"
             }
         },
         "weather": {


### PR DESCRIPTION
## Problem

`meteo_meteogrammi_tabella` publishes a `BFOGL` reading ("Bagnatura fogliare",
leaf wetness) on stations equipped for agrometeorology — every 15 minutes on
mine (Sant'Elena, Padova):

```json
{"nome_sensore": "Bagnatura fogliare", "tipo": "BFOGL", "valore": "71", "unitnm": "% T"}
```

It is currently the only published parameter the integration drops:
`fetch_station_data` doesn't handle the type and there is no entry in
`SENSOR_TYPES`.

## Changes

- read `BFOGL` in `fetch_station_data`;
- add a `leaf_wetness` sensor: `%`, `moisture` device class, `measurement` state
  class (the device class also provides the icon, so `icons.json` isn't needed);
- EN/IT names.

Stations without the sensor are unaffected: the value is simply absent, exactly
as `VISIB` and `PRESS` already are on many stations.

## Testing

Running on HA 2026.8.2 against station 300003280 (Sant'Elena, Padova). After a
restart the new entity appears as
`sensor.arpa_veneto_weather_bagnatura_fogliare_a_sant_elena_padova` and tracks
the API: `0.0` here, matching the last four published samples (21:00–21:45, all
`0`). No warnings in the log; existing entities are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
