### PR TITLE
fix: apply the custom sky thresholds actually configured

### DIFF
--- a/custom_components/arpa_veneto_weather/coordinator.py
+++ b/custom_components/arpa_veneto_weather/coordinator.py
@@ -81,19 +81,22 @@ class ArpaVenetoDataUpdateCoordinator(DataUpdateCoordinator):
                     self.latitude, self.longitude, sensor_data, forecast=forecast_data)
             case const.CONF_INFER_CONDITION_FROM_SENSORS_WITH_CUSTOM_THRESHOLDS:
                 opts = self.config_entry.options
-                if opts.get("override_thresholds"):
-                    day_cfg = DayThresholds(
-                        clear_ratio=opts.get(
-                            "day_clear_ratio", const.CONF_INFER_CONDITION_DAY_CLEAR_THRESHOLD_DEFAULT),
-                        partly_ratio=opts.get(
-                            "day_partly_ratio", const.CONF_INFER_CONDITION_DAY_PARTLY_THRESHOLD_DEFAULT),
-                    )
-                    night_cfg = NightThresholds(
-                        cloudy_humidity=opts.get(
-                            "night_cloudy_humidity", const.CONF_INFER_CONDITION_NIGHT_CLEAR_THRESHOLD_DEFAULT),
-                        dark_moon=opts.get(
-                            "night_dark_moon", const.CONF_INFER_CONDITION_NIGHT_PARTLY_THRESHOLD_DEFAULT),
-                    )
+                day_cfg = DayThresholds(
+                    clear=opts.get(
+                        const.CONF_INFER_CONDITION_DAY_CLEAR_THRESHOLD,
+                        const.CONF_INFER_CONDITION_DAY_CLEAR_THRESHOLD_DEFAULT),
+                    partly_cloudy=opts.get(
+                        const.CONF_INFER_CONDITION_DAY_PARTLY_THRESHOLD,
+                        const.CONF_INFER_CONDITION_DAY_PARTLY_THRESHOLD_DEFAULT),
+                )
+                night_cfg = NightThresholds(
+                    clear=opts.get(
+                        const.CONF_INFER_CONDITION_NIGHT_CLEAR_THRESHOLD,
+                        const.CONF_INFER_CONDITION_NIGHT_CLEAR_THRESHOLD_DEFAULT),
+                    partly_cloudy=opts.get(
+                        const.CONF_INFER_CONDITION_NIGHT_PARTLY_THRESHOLD,
+                        const.CONF_INFER_CONDITION_NIGHT_PARTLY_THRESHOLD_DEFAULT),
+                )
 
                 sensor_data["condition"] = await self._compute_condition_from_sensors(
                     self.latitude, self.longitude, sensor_data, day_cfg, night_cfg, forecast=forecast_data)


### PR DESCRIPTION
Follow-up to the discussion in #50, split into focused pull requests as you asked. This is the first of five; they are stacked in this order, so each diff gets smaller as the previous one lands:

1. **this one** — fix the custom thresholds
2. `feat/observation-provenance` — make the source of every value explicit
3. `feat/metar-observations` — opt-in METAR observations and the configurable night condition
4. `fix/refresh-data-service` — fix the `refresh_data` service
5. `feat/brightness-statistics` — optional brightness archive

## The bug

The custom-thresholds branch reads option keys the config flow never writes:

```python
if opts.get("override_thresholds"):          # never set
    day_cfg = DayThresholds(
        clear_ratio=opts.get("day_clear_ratio", ...),          # key is "day_clear_threshold"
    night_cfg = NightThresholds(
        cloudy_humidity=opts.get("night_cloudy_humidity", ...) # key is "night_clear_threshold"
```

The thresholds step stores `day_clear_threshold`, `day_partly_threshold`, `night_clear_threshold` and `night_partly_threshold`, and there is no `override_thresholds` option at all. So choosing *From sensors using custom thresholds* silently keeps using the built-in defaults.

The same code would also raise `TypeError: DayThresholds.__init__() got an unexpected keyword argument 'clear_ratio'` if the guard were ever true: the dataclass fields are `clear` and `partly_cloudy`.

## The fix

Read the documented keys, pass the right keyword arguments, and drop the guard — selecting that option *is* the opt-in.

Tested on my instance: setting a night clear threshold of 19.0 now actually reaches `classify_sky`, where before the value was ignored.
