### PR TITLE
feat: expose where every observation comes from

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,37 @@ for separately switching between <i>clear</i>, <i>partly cloudy</i> and <i>cloud
 during day and night.
 
 
+## Data provenance
+
+A single weather station in Home Assistant is fed by several distinct ARPAV
+networks: the [meteogram](https://www.arpa.veneto.it/dati-ambientali/dati-in-diretta/meteo-idro-nivo/variabili_meteo)
+network for the observations, the [air quality](https://www.arpa.veneto.it/dati-ambientali/dati-in-diretta/aria/qualita-aria-dati-in-diretta)
+network, the [night sky brightness](https://www.arpa.veneto.it/dati-ambientali/dati-in-diretta/luminosita-del-cielo/brillanza)
+network and the forecast bulletin. They have different locations, different
+sampling intervals and different publishing latencies, and not every value is
+an observation: some are forecasts.
+
+Every entity therefore reports where its value comes from, as extra state
+attributes:
+
+| Attribute | Description |
+| --------- | ----------- |
+| `source` | Origin of the value: `station`, `air_quality_station`, `sky_brightness_station`, `forecast` or `unknown` |
+| `source_name` | The reporting station, or the forecast zone |
+| `source_observed_at` | When the value was observed at the origin, which can be well before the last update |
+
+The weather entity exposes the same information for the current condition,
+prefixed with `condition_`, plus `condition_source_rule`: the criterion that
+decided the condition, one of `precipitation`, `visibility`, `wind`,
+`solar_radiation`, `sky_brightness` or `forecast`.
+
+> [!TIP]
+`condition_source` is the honest way to tell a measured condition from a
+forecast one: for example a `cloudy` state coming from
+`source: station, source_rule: solar_radiation` is measured sunlight, while
+`source: forecast` means the sky could not be measured and the bulletin was
+used instead.
+
 ## Expose raw data
 
 In order to get the raw data for advanced stuff in HA, from the UI go to

--- a/custom_components/arpa_veneto_weather/const.py
+++ b/custom_components/arpa_veneto_weather/const.py
@@ -24,6 +24,21 @@ CONF_INFER_CONDITION_NIGHT_CLEAR_THRESHOLD_DEFAULT = 20.5
 CONF_INFER_CONDITION_NIGHT_PARTLY_THRESHOLD = "night_partly_threshold"
 CONF_INFER_CONDITION_NIGHT_PARTLY_THRESHOLD_DEFAULT = 18.5
 
+# Origin of an observation, exposed as the "source" attribute
+SOURCE_STATION = "station"
+SOURCE_AIR_QUALITY_STATION = "air_quality_station"
+SOURCE_BRIGHTNESS_STATION = "sky_brightness_station"
+SOURCE_FORECAST = "forecast"
+SOURCE_UNKNOWN = "unknown"
+
+# Criterion that decided the computed condition, exposed as "source_rule"
+RULE_PRECIPITATION = "precipitation"
+RULE_VISIBILITY = "visibility"
+RULE_WIND = "wind"
+RULE_SOLAR_RADIATION = "solar_radiation"
+RULE_SKY_BRIGHTNESS = "sky_brightness"
+RULE_FORECAST = "forecast"
+
 CONF_AIR_QUALITY = "air_quality"
 CONF_PM10_STATION = "pm10_station"
 CONF_PM25_STATION = "pm25_station"

--- a/custom_components/arpa_veneto_weather/coordinator.py
+++ b/custom_components/arpa_veneto_weather/coordinator.py
@@ -81,19 +81,22 @@ class ArpaVenetoDataUpdateCoordinator(DataUpdateCoordinator):
                     self.latitude, self.longitude, sensor_data, forecast=forecast_data)
             case const.CONF_INFER_CONDITION_FROM_SENSORS_WITH_CUSTOM_THRESHOLDS:
                 opts = self.config_entry.options
-                if opts.get("override_thresholds"):
-                    day_cfg = DayThresholds(
-                        clear_ratio=opts.get(
-                            "day_clear_ratio", const.CONF_INFER_CONDITION_DAY_CLEAR_THRESHOLD_DEFAULT),
-                        partly_ratio=opts.get(
-                            "day_partly_ratio", const.CONF_INFER_CONDITION_DAY_PARTLY_THRESHOLD_DEFAULT),
-                    )
-                    night_cfg = NightThresholds(
-                        cloudy_humidity=opts.get(
-                            "night_cloudy_humidity", const.CONF_INFER_CONDITION_NIGHT_CLEAR_THRESHOLD_DEFAULT),
-                        dark_moon=opts.get(
-                            "night_dark_moon", const.CONF_INFER_CONDITION_NIGHT_PARTLY_THRESHOLD_DEFAULT),
-                    )
+                day_cfg = DayThresholds(
+                    clear=opts.get(
+                        const.CONF_INFER_CONDITION_DAY_CLEAR_THRESHOLD,
+                        const.CONF_INFER_CONDITION_DAY_CLEAR_THRESHOLD_DEFAULT),
+                    partly_cloudy=opts.get(
+                        const.CONF_INFER_CONDITION_DAY_PARTLY_THRESHOLD,
+                        const.CONF_INFER_CONDITION_DAY_PARTLY_THRESHOLD_DEFAULT),
+                )
+                night_cfg = NightThresholds(
+                    clear=opts.get(
+                        const.CONF_INFER_CONDITION_NIGHT_CLEAR_THRESHOLD,
+                        const.CONF_INFER_CONDITION_NIGHT_CLEAR_THRESHOLD_DEFAULT),
+                    partly_cloudy=opts.get(
+                        const.CONF_INFER_CONDITION_NIGHT_PARTLY_THRESHOLD,
+                        const.CONF_INFER_CONDITION_NIGHT_PARTLY_THRESHOLD_DEFAULT),
+                )
 
                 sensor_data["condition"] = await self._compute_condition_from_sensors(
                     self.latitude, self.longitude, sensor_data, day_cfg, night_cfg, forecast=forecast_data)

--- a/custom_components/arpa_veneto_weather/coordinator.py
+++ b/custom_components/arpa_veneto_weather/coordinator.py
@@ -9,11 +9,13 @@ from .const import (
     API_BASE, CARDINAL_DIRECTIONS, DOMAIN
 )
 
+from .provenance import Provenance
 from .thresholds import DayThresholds, NightThresholds
 
 from astral import LocationInfo
 from astral.sun import sun, elevation
 from astral.moon import phase
+from dataclasses import dataclass
 from datetime import datetime, timezone, timedelta, UTC
 from math import radians, cos, sin, asin, sqrt
 
@@ -31,6 +33,16 @@ BRIGHTNESS_MAX_STATIONS = 5
 # readings older than this no longer describe the current sky
 BRIGHTNESS_MAX_AGE_HOURS = 6
 
+
+@dataclass
+class SkyBrightnessReading:
+    """A night sky brightness reading, with the station that observed it."""
+
+    value: float
+    station_name: str | None = None
+    observed_at: str | None = None
+
+
 class ArpaVenetoDataUpdateCoordinator(DataUpdateCoordinator):
     """Data update coordinator for ARPA Veneto."""
 
@@ -38,6 +50,7 @@ class ArpaVenetoDataUpdateCoordinator(DataUpdateCoordinator):
         """Initialize the data update coordinator."""
         self.station_id = config_entry.data.get("station_id")
         self.zone_id = config_entry.data.get("zone_id")
+        self.zone_name = config_entry.data.get("zone_name")
         self.latitude = config_entry.data.get("station_latitude")
         self.longitude = config_entry.data.get("station_longitude")
         self.infer_condition = config_entry.options.get(const.CONF_INFER_CONDITION)
@@ -66,18 +79,36 @@ class ArpaVenetoDataUpdateCoordinator(DataUpdateCoordinator):
         pm25_response = self.fetch_air_quality_data(
             self.pm25_station_id, 'PM2.5') if self.pm25_station_id and self.pm25_station_id != "None" else None
 
-        sensor_data, sensor_data_raw = await sensor_response
+        sensor_data, sensor_data_raw, sources = await sensor_response
         forecast_data, forecast_raw = await forecast_response
-        sensor_data["pm10"] = (await pm10_response).get("MEDIA", None) if pm10_response else None
-        sensor_data["pm25"] = (await pm25_response).get("MEDIA", None) if pm25_response else None
-        sensor_data["ozone"] = (await ozone_response).get("MEDIA", None) if ozone_response else None
+
+        for key, response in (("pm10", pm10_response),
+                              ("pm25", pm25_response),
+                              ("ozone", ozone_response)):
+            latest = await response if response else None
+            sensor_data[key] = latest.get("MEDIA", None) if latest else None
+            if latest:
+                sources[key] = Provenance(
+                    source=const.SOURCE_AIR_QUALITY_STATION,
+                    name=latest.get("STAZIONE"),
+                    observed_at=_arpav_isoformat(latest.get("DATA")),
+                )
+
+        # this one is a forecast, not an observation: it comes from the bulletin
+        nearest_forecast = self._nearest_forecast(datetime.now(), forecast_data)
+        if nearest_forecast:
+            sources["precipitation_probability"] = Provenance(
+                source=const.SOURCE_FORECAST,
+                name=self.zone_name,
+                observed_at=nearest_forecast["datetime"].isoformat(),
+            )
 
         day_cfg = DayThresholds()
         night_cfg = NightThresholds()
         # Determine the current condition based on configuration
         match self.infer_condition:
             case const.CONF_INFER_CONDITION_FROM_SENSORS | None:
-                sensor_data["condition"] = await self._compute_condition_from_sensors(
+                sensor_data["condition"], sources["condition"] = await self._compute_condition_from_sensors(
                     self.latitude, self.longitude, sensor_data, forecast=forecast_data)
             case const.CONF_INFER_CONDITION_FROM_SENSORS_WITH_CUSTOM_THRESHOLDS:
                 opts = self.config_entry.options
@@ -98,7 +129,7 @@ class ArpaVenetoDataUpdateCoordinator(DataUpdateCoordinator):
                         const.CONF_INFER_CONDITION_NIGHT_PARTLY_THRESHOLD_DEFAULT),
                 )
 
-                sensor_data["condition"] = await self._compute_condition_from_sensors(
+                sensor_data["condition"], sources["condition"] = await self._compute_condition_from_sensors(
                     self.latitude, self.longitude, sensor_data, day_cfg, night_cfg, forecast=forecast_data)
             case _:  # CONF_INFER_CONDITION_DISABLED or any other value
                 pass  # Do not compute condition
@@ -108,6 +139,7 @@ class ArpaVenetoDataUpdateCoordinator(DataUpdateCoordinator):
             "forecast_raw": forecast_raw,
             "sensors": sensor_data,  # Include sensor data like temperature
             "sensors_raw": sensor_data_raw,
+            "sources": sources,  # Where each value comes from, keyed as in "sensors"
         }
 
     async def fetch_station_data(self, station_id):
@@ -136,44 +168,22 @@ class ArpaVenetoDataUpdateCoordinator(DataUpdateCoordinator):
         filtered_data = list(latest_by_type.values())
 
         extracted_data = {}
+        sources = {}
         # Extract temperature, humidity, and other data
         for entry in filtered_data:
             extracted_data["station_name"] = entry.get("nome_stazione")
 
-            tipo = entry.get("tipo")
-            valore = entry.get("valore")
-            # latitudine = entry.get("latitudine")
-            # longitudine = entry.get("longitudine")
+            values = _values_from_observation(entry)
+            extracted_data.update(values)
 
-            if tipo.startswith("TARIA"):
-                extracted_data["temperature"] = float(valore)
-            elif tipo.startswith("UMID"):
-                extracted_data["humidity"] = int(valore)
-            elif tipo == "VISIB":
-                extracted_data["visibility"] = round(int(valore) / 1000, 2)
-            elif tipo == "PRESS":
-                extracted_data["pressure"] = float(valore)
-            elif tipo == "PREC":
-                extracted_data["precipitation"] = float(valore)
-            elif tipo.startswith("DVENTO"):
-                degrees = int(valore)
-                extracted_data["native_wind_bearing"] = degrees
-                extracted_data["wind_bearing"] = CARDINAL_DIRECTIONS[int((degrees + 11.25)/22.5)]
-            elif tipo.startswith("VVENTO"):
-                extracted_data["wind_speed"] = round(float(valore) * 3.6, 2)
-            elif tipo == "RADSOL":
-                # Assuming UV Fraction = 6% => 0.06
-                if (entry.get("unitnm") == "MJ/m2"):
-                    # For MJ/m², the scaling factor is 40 because it includes cumulative energy and time
-                    extracted_data["uv_index"] = round(float(valore) * 0.06 * 40)
-                    extracted_data["ghi"] = round(mj_to_wm2(float(valore), 3600))
-                elif (entry.get("unitnm") == "w/m2"):
-                    # For W/m², the scaling factor is 0.04 because it represents instantaneous power
-                    extracted_data["uv_index"] = round(float(valore) * 0.06 * 0.04)
-                    extracted_data["ghi"] = round(float(valore))
-            elif tipo == "BFOGL":
-                # Leaf wetness, reported as the share of the interval the leaf was wet
-                extracted_data["leaf_wetness"] = float(valore)
+            # each observation carries its own timestamp, so track it per value
+            observed_at = _arpav_isoformat(entry.get("dataora"))
+            for key in values:
+                sources[key] = Provenance(
+                    source=const.SOURCE_STATION,
+                    name=entry.get("nome_stazione"),
+                    observed_at=observed_at,
+                )
 
         # prepare additional precipitation metrics
         # given that
@@ -215,18 +225,30 @@ class ArpaVenetoDataUpdateCoordinator(DataUpdateCoordinator):
             precipitation_cumulative_today = _cumulate_since(precipitation_data, midnight)
 
             # Add these computed metrics to the extracted_data dictionary
-            extracted_data["precipitation_hourly"] = precipitation_hourly
-            extracted_data["precipitation_cumulative_today"] = precipitation_cumulative_today
-            extracted_data["precipitation_cumulative_1h"] = precipitation_cumulative_1h
-            extracted_data["precipitation_cumulative_3h"] = precipitation_cumulative_3h
-            extracted_data["precipitation_cumulative_6h"] = precipitation_cumulative_6h
-            extracted_data["precipitation_cumulative_12h"] = precipitation_cumulative_12h
-            extracted_data["precipitation_cumulative_24h"] = precipitation_cumulative_24h
+            computed = {
+                "precipitation_hourly": precipitation_hourly,
+                "precipitation_cumulative_today": precipitation_cumulative_today,
+                "precipitation_cumulative_1h": precipitation_cumulative_1h,
+                "precipitation_cumulative_3h": precipitation_cumulative_3h,
+                "precipitation_cumulative_6h": precipitation_cumulative_6h,
+                "precipitation_cumulative_12h": precipitation_cumulative_12h,
+                "precipitation_cumulative_24h": precipitation_cumulative_24h,
+            }
+            extracted_data.update(computed)
+
+            # they are aggregates of the station data points, up to the latest one
+            observed_at = _arpav_isoformat(precipitation_data[0].get("dataora"))
+            for key in computed:
+                sources[key] = Provenance(
+                    source=const.SOURCE_STATION,
+                    name=extracted_data.get("station_name"),
+                    observed_at=observed_at,
+                )
 
         extracted_data["last_update"] = datetime.now().isoformat()
         extracted_data["dt"] = dataora
 
-        return extracted_data, filtered_data
+        return extracted_data, filtered_data, sources
 
     async def fetch_air_quality_data(self, station_id, parametro):
         """Fetch air quality data from the station."""
@@ -271,7 +293,8 @@ class ArpaVenetoDataUpdateCoordinator(DataUpdateCoordinator):
         :param day_cfg: the day thresholds configuration
         :param night_cfg: the night thresholds configuration
         :param forecast: assembled forecast entries, used as a night fallback
-        :return: string ["clear-night", "partlycloudy", "cloudy", "unknown"]
+        :return: a tuple with the condition string ["clear-night", "partlycloudy", "cloudy", "unknown"]
+            and the Provenance of the data that decided it
         """
 
         temperature = sensor_data.get("temperature")
@@ -282,27 +305,38 @@ class ArpaVenetoDataUpdateCoordinator(DataUpdateCoordinator):
 
         ghi = sensor_data.get("ghi")
 
+        def measured(rule):
+            """Return the provenance of a condition decided by the station."""
+
+            return Provenance(
+                source=const.SOURCE_STATION,
+                name=sensor_data.get("station_name"),
+                observed_at=_arpav_isoformat(sensor_data.get("dt")),
+                rule=rule,
+            )
+
         # Precipitation overrides everything
         if precipitation is not None and precipitation > 0:
+            rain = measured(const.RULE_PRECIPITATION)
             if temperature is not None:
                 # lowest threshold first, otherwise the second branch is dead code
                 if temperature <= 0:
-                    return "snowy"
+                    return "snowy", rain
                 elif temperature <= 5:
-                    return "snowy-rainy"
+                    return "snowy-rainy", rain
                 if precipitation > 20:
-                    return "pouring"
-            return "rainy"
+                    return "pouring", rain
+            return "rainy", rain
 
         # Visibility overrides wind
         if visibility is not None:
             if visibility < 1:
-                return "fog"
+                return "fog", measured(const.RULE_VISIBILITY)
             if visibility < 2 and humidity and humidity > 99:
-                return "fog"
+                return "fog", measured(const.RULE_VISIBILITY)
 
         if wind_speed and wind_speed > 30:
-            return "windy"
+            return "windy", measured(const.RULE_WIND)
 
         city = LocationInfo(latitude=lat, longitude=lon)
         s = sun(city.observer, date=dt.date(), tzinfo=dt.tzinfo)
@@ -310,14 +344,17 @@ class ArpaVenetoDataUpdateCoordinator(DataUpdateCoordinator):
         is_day = s["sunrise"] <= dt <= s["sunset"]
 
         if is_day:
+            radiation = measured(const.RULE_SOLAR_RADIATION)
+
             if ghi is None:
-                return "unknown"
+                return "unknown", Provenance(source=const.SOURCE_UNKNOWN)
 
             # Sun elevation in degrees
             h_sun = elevation(city.observer, dt)
 
             if h_sun <= 0:
-                return "unknown"  # Sun below horizon (transitions)
+                # Sun below horizon (transitions)
+                return "unknown", Provenance(source=const.SOURCE_UNKNOWN)
 
             # Theoretical maximum irradiance (approximated)
             ghi_clear = 1000 * sin(radians(h_sun))
@@ -327,20 +364,27 @@ class ArpaVenetoDataUpdateCoordinator(DataUpdateCoordinator):
 
             # Empirical thresholds (to be calibrated on ARPA data)
             if ghi_ratio > day_cfg.clear:
-                return "sunny"
+                return "sunny", radiation
             elif ghi_ratio > day_cfg.partly_cloudy:
-                return "partlycloudy"
+                return "partlycloudy", radiation
             else:
                 if wind_speed and wind_speed > 30:
-                    return "windy-variant"
-                return "cloudy"
+                    return "windy-variant", measured(const.RULE_WIND)
+                return "cloudy", radiation
 
         else:
-            sky_brightness = await self.get_night_sky_brightness(lat, lon)
-            if sky_brightness is None:
+            reading = await self.get_night_sky_brightness(lat, lon)
+            if reading is None:
                 # the brightness network is published in daily batches, so at
                 # night there is often no fresh reading: fall back to the bulletin
-                return self._forecast_condition_at(dt, forecast, night=True) or "unknown"
+                return self._forecast_condition(dt, forecast, night=True)
+
+            brightness = Provenance(
+                source=const.SOURCE_BRIGHTNESS_STATION,
+                name=reading.station_name,
+                observed_at=reading.observed_at,
+                rule=const.RULE_SKY_BRIGHTNESS,
+            )
 
             illum = moon_illumination(dt)
             if illum > 50:
@@ -350,17 +394,35 @@ class ArpaVenetoDataUpdateCoordinator(DataUpdateCoordinator):
             else:
                 offset = 0
 
-            if sky_brightness + offset > night_cfg.clear:
-                return "clear-night"
-            elif sky_brightness + offset > night_cfg.partly_cloudy:
-                return "partlycloudy"
+            if reading.value + offset > night_cfg.clear:
+                return "clear-night", brightness
+            elif reading.value + offset > night_cfg.partly_cloudy:
+                return "partlycloudy", brightness
             else:
                 if wind_speed and wind_speed > 30:
-                    return "windy-variant"
-                return "cloudy"
+                    return "windy-variant", measured(const.RULE_WIND)
+                return "cloudy", brightness
 
-    def _forecast_condition_at(self, dt, forecast, night=False):
-        """Return the forecast condition closest to the given datetime, or None."""
+    def _forecast_condition(self, dt, forecast, night=False):
+        """Return the forecast condition closest to a datetime, with its provenance."""
+
+        nearest = self._nearest_forecast(dt, forecast)
+        if nearest is None:
+            return "unknown", Provenance(source=const.SOURCE_UNKNOWN)
+
+        condition = nearest["condition"]
+        if night and condition in ("sunny", "clear"):
+            condition = "clear-night"
+
+        return condition, Provenance(
+            source=const.SOURCE_FORECAST,
+            name=self.zone_name,
+            observed_at=nearest["datetime"].isoformat(),
+            rule=const.RULE_FORECAST,
+        )
+
+    def _nearest_forecast(self, dt, forecast):
+        """Return the forecast entry closest to the given datetime, or None."""
 
         candidates = [
             f for f in (forecast or [])
@@ -372,15 +434,10 @@ class ArpaVenetoDataUpdateCoordinator(DataUpdateCoordinator):
             return None
 
         target = dt.replace(tzinfo=None)
-        nearest = min(candidates, key=lambda f: abs(f["datetime"] - target))
-        condition = nearest["condition"]
-
-        if night and condition in ("sunny", "clear"):
-            return "clear-night"
-        return condition
+        return min(candidates, key=lambda f: abs(f["datetime"] - target))
 
     async def get_night_sky_brightness(self, lat, lon):
-        """Approximate night sky brightness (mag/arcsec²) based on location."""
+        """Return the nearest usable night sky brightness reading, or None."""
 
         url = f"{API_BASE}/meteo_meteogrammi?rete=MGRAMMIBRI&coordcd=20067&orario=0"
         async with aiohttp.ClientSession() as session, session.get(url) as response:
@@ -392,14 +449,15 @@ class ArpaVenetoDataUpdateCoordinator(DataUpdateCoordinator):
         stations = sort_locations_by_distance(data.get("data", []), lat, lon)
 
         for station in stations[:BRIGHTNESS_MAX_STATIONS]:
-            sky_brightness = await self._fetch_station_brightness(station.get("codseqst"))
-            if sky_brightness is not None:
-                return sky_brightness
+            reading = await self._fetch_station_brightness(
+                station.get("codseqst"), station.get("nome_stazione"))
+            if reading is not None:
+                return reading
 
         _LOGGER.debug("No usable sky brightness reading from the nearby stations")
         return None
 
-    async def _fetch_station_brightness(self, codseqst):
+    async def _fetch_station_brightness(self, codseqst, station_name=None):
         """Return the latest usable brightness reading of a station, or None."""
 
         if codseqst is None:
@@ -436,7 +494,72 @@ class ArpaVenetoDataUpdateCoordinator(DataUpdateCoordinator):
         if datetime.now() - reading_dt > timedelta(hours=BRIGHTNESS_MAX_AGE_HOURS):
             return None
 
-        return sky_brightness
+        return SkyBrightnessReading(
+            value=sky_brightness,
+            station_name=station_name or latest.get("nome_stazione"),
+            observed_at=_arpav_isoformat(latest.get("dataora")),
+        )
+
+
+def _values_from_observation(entry):
+    """Map a single meteogram observation to the sensor values it feeds."""
+
+    tipo = entry.get("tipo")
+    valore = entry.get("valore")
+
+    if tipo is None or valore is None:
+        return {}
+
+    if tipo.startswith("TARIA"):
+        return {"temperature": float(valore)}
+    if tipo.startswith("UMID"):
+        return {"humidity": int(valore)}
+    if tipo == "VISIB":
+        return {"visibility": round(int(valore) / 1000, 2)}
+    if tipo == "PRESS":
+        return {"pressure": float(valore)}
+    if tipo == "PREC":
+        return {"precipitation": float(valore)}
+    if tipo.startswith("DVENTO"):
+        degrees = int(valore)
+        return {
+            "native_wind_bearing": degrees,
+            "wind_bearing": CARDINAL_DIRECTIONS[int((degrees + 11.25)/22.5)],
+        }
+    if tipo.startswith("VVENTO"):
+        return {"wind_speed": round(float(valore) * 3.6, 2)}
+    if tipo == "RADSOL":
+        # Assuming UV Fraction = 6% => 0.06
+        if (entry.get("unitnm") == "MJ/m2"):
+            # For MJ/m², the scaling factor is 40 because it includes cumulative energy and time
+            return {
+                "uv_index": round(float(valore) * 0.06 * 40),
+                "ghi": round(mj_to_wm2(float(valore), 3600)),
+            }
+        if (entry.get("unitnm") == "w/m2"):
+            # For W/m², the scaling factor is 0.04 because it represents instantaneous power
+            return {
+                "uv_index": round(float(valore) * 0.06 * 0.04),
+                "ghi": round(float(valore)),
+            }
+        return {}
+    if tipo == "BFOGL":
+        # Leaf wetness, reported as the share of the interval the leaf was wet
+        return {"leaf_wetness": float(valore)}
+
+    return {}
+
+
+def _arpav_isoformat(dataora):
+    """Return an ARPAV timestamp as an ISO string, with its fixed +0100 offset."""
+
+    if not dataora:
+        return None
+
+    try:
+        return datetime.strptime(dataora + " +0100", "%Y-%m-%dT%H:%M:%S %z").isoformat()
+    except (TypeError, ValueError):
+        return dataora
 
 
 def find_nearest_location(locations, target_lat, target_lon):

--- a/custom_components/arpa_veneto_weather/provenance.py
+++ b/custom_components/arpa_veneto_weather/provenance.py
@@ -1,0 +1,38 @@
+"""Provenance of the observations feeding the entities.
+
+A single weather station in Home Assistant is fed by several ARPAV networks
+(meteogram, air quality, night sky brightness) and by the forecast bulletin,
+each with its own location and its own publishing latency. Every value
+therefore carries the origin it was observed by, exposed as extra state
+attributes, so that a measurement can be told apart from a forecast.
+"""
+
+from dataclasses import dataclass
+
+
+@dataclass
+class Provenance:
+    """Where a single observation comes from."""
+
+    source: str
+    """Machine readable origin, one of the SOURCE_* constants."""
+
+    name: str | None = None
+    """Human readable origin, typically the name of the reporting station."""
+
+    observed_at: str | None = None
+    """Timestamp of the observation, as reported by the origin."""
+
+    rule: str | None = None
+    """For the computed condition only: the criterion that decided it."""
+
+    def as_attributes(self) -> dict:
+        """Return the provenance as extra state attributes, skipping empty fields."""
+
+        attributes = {
+            "source": self.source,
+            "source_name": self.name,
+            "source_observed_at": self.observed_at,
+            "source_rule": self.rule,
+        }
+        return {key: value for key, value in attributes.items() if value is not None}

--- a/custom_components/arpa_veneto_weather/sensor.py
+++ b/custom_components/arpa_veneto_weather/sensor.py
@@ -71,11 +71,18 @@ class ArpaVenetoSensor(CoordinatorEntity[DataUpdateCoordinator], SensorEntity):
 
     @property
     def extra_state_attributes(self):
-        """Return additional attributes."""
-        return {
+        """Return additional attributes, including where the value comes from."""
+        attributes = {
             "station_id": self.station_id,
             "last_update": self.coordinator.data["sensors"].get("last_update"),
         }
+
+        # the entities of a single station are fed by different networks
+        provenance = self.coordinator.data.get("sources", {}).get(self.sensor_type)
+        if provenance:
+            attributes.update(provenance.as_attributes())
+
+        return attributes
 
     async def async_update(self):
         """Update the sensor state."""

--- a/custom_components/arpa_veneto_weather/weather.py
+++ b/custom_components/arpa_veneto_weather/weather.py
@@ -230,6 +230,12 @@ class ArpaVenetoWeatherEntity(CoordinatorEntity, WeatherEntity):
             "forecast_today_reliability": get_attr(nearest, "forecast_reliability"),
         }
 
+        # tell a measured condition apart from a forecast one
+        provenance = self.coordinator.data.get("sources", {}).get("condition")
+        if provenance:
+            payload.update({f"condition_{key}": value
+                            for key, value in provenance.as_attributes().items()})
+
         if self.expose_forecast_json:
             json_forecast = json.dumps(forecasts, indent=2, cls=DateTimeEncoder)
             payload["forecast"] = json_forecast


### PR DESCRIPTION
Second of the five PRs from #50 (stacked on #54). This is the "make it explicit" part you agreed with, and it is what makes the next PR honest.

## Why

A station in Home Assistant is fed by several ARPAV networks — meteogram, air quality, night sky brightness — plus the forecast bulletin. They sit in different places, sample at different rates and publish with different latencies, and some values are not observations at all. None of that was visible:

- `weather.arpav` showing `cloudy` could be measured sunlight or a bulletin symbol, which is exactly the concern you raised in #50;
- the precipitation probability sensor sits next to the measured ones and looks like one, but comes from the bulletin;
- the air quality values come from a different station, possibly tens of kilometres away, and can be hours old;
- `last_update` is when *we* fetched, not when the value was *observed*: at Sant'Elena the two differ by up to 20 minutes, and for air quality by hours.

## What it does

Every value carries where it came from, exposed as extra state attributes:

| Attribute | Example |
| --------- | ------- |
| `source` | `station`, `air_quality_station`, `sky_brightness_station`, `forecast`, `unknown` |
| `source_name` | `Sant'Elena`, `Monselice via BM Teresa di Calcutta`, `Rovigo e pianura meridionale` |
| `source_observed_at` | `2026-08-18T12:20:00+01:00` |

The weather entity exposes the same with a `condition_` prefix, plus `condition_source_rule`: which criterion decided the condition (`precipitation`, `visibility`, `wind`, `solar_radiation`, `sky_brightness`, `forecast`).

Live on my instance right now:

```
weather:                condition_source=station  rule=solar_radiation  at=2026-08-18T12:20:00+01:00
sensor temperature:     source=station            name=Sant'Elena       at=2026-08-18T12:20:00+01:00
sensor precip. prob.:   source=forecast           name=Rovigo e pianura meridionale
sensor pm10:            source=air_quality_station name=Monselice via BM Teresa di Calcutta at=2026-08-18T00:00:00+01:00
```

That last line is the point of the whole PR: the PM10 value was 13 hours old and looked as current as the temperature.

## How

- new `provenance.py` with a small `Provenance` dataclass and its rendering to attributes;
- the coordinator returns a `sources` dict keyed exactly like `sensors`, so consumers can look up any value's origin;
- `classify_sky` returns `(condition, provenance)` instead of a bare string;
- the meteogram parsing moved into `_values_from_observation`, which declares which values an observation feeds, so each one gets that observation's own `dataora` rather than a single timestamp for the whole payload. It also no longer calls `float(None)` on an empty `valore`.

No entity, unit or state changes: only new attributes. `sources` is additive in the coordinator payload.
