### PR TITLE
feat: optionally complete the data with METAR observations

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ Once you have configured a station, you can control some options from ⚙ (its _
 - **Expose extra attributes for raw original sensor data**: Expose as sensors the data obtaining from the remote api call
 - **Compute the current condition**: Expose the weather state as computed from available metrics
 - **Choose stations providing air-quality data**: Since the set of [stations differs](https://www.arpa.veneto.it/dati-ambientali/dati-in-diretta/aria/qualita-aria-dati-in-diretta) between PM10, PM2.5 and Ozone, the user can choose a specific station for each of them. 
+- **Current condition at night**: Choose which source describes the sky while the sun is below the horizon
+- **Additional observations**: Optionally choose an aerodrome publishing METAR reports, to observe the sky and to complete the data the chosen station does not provide
 
 ## Compute the current weather condition
 
@@ -114,6 +116,76 @@ using custom thresholds</b></i> to set custom thresholds
 for separately switching between <i>clear</i>, <i>partly cloudy</i> and <i>cloudy</i>
 during day and night.
 
+### The current condition at night
+
+Daylight is measured by the station itself, so the daytime sky is inferred from
+a local, near real-time observation. The night is the hard part, because no
+single source works everywhere:
+
+- the **night sky brightness** network publishes its readings in a single daily
+  batch (around 09:30, standard time), so at night the latest reading normally
+  describes the *previous* night rather than the current one, and is discarded
+  as stale;
+- the **forecast bulletin** is always available and covers the whole region, but
+  it is a forecast, not an observation;
+- a **METAR** report is an actual observation of the sky, published every 30
+  minutes, but it comes from the nearest aerodrome, which may be tens of
+  kilometres away;
+- some setups are better off with **no value at all** than with a value that is
+  not measured.
+
+The choice is therefore left to the user, under _Current condition at night_:
+
+| Option | Behaviour |
+| ------ | --------- |
+| _Sky brightness, forecast as a fallback_ | The default, and the historical behaviour: use the brightness reading when it is fresh enough, otherwise the bulletin |
+| _Sky brightness only_ | Use the brightness reading when fresh, otherwise leave the condition unknown |
+| _METAR observation, forecast as a fallback_ | Use the cloud cover observed by the configured aerodrome, and the bulletin when no report is available |
+| _Forecast bulletin_ | Always use the bulletin |
+| _Leave it unknown_ | Report no condition unless the station measurements alone decide it (rain, fog, wind) |
+
+Whatever the choice, the weather entity says which one was used through its
+`condition_source` attributes: see [Data provenance](#data-provenance).
+
+## Additional observations
+
+ARPAV stations do not observe the state of the sky, and several of them report
+neither visibility nor pressure: those sensors stay `unknown`. Aerodromes do
+observe all of it, and publish a
+[METAR](https://en.wikipedia.org/wiki/METAR) report every 30 minutes, with cloud
+cover reported layer by layer.
+
+Under _Additional observations_ you can select one, from the list of aerodromes
+around the station, **sorted by distance**. When configured, it provides:
+
+- the **cloud coverage** of the weather entity, as a percentage of the sky;
+- the **current condition at night**, if you selected the METAR option above;
+- any value **missing** from the chosen ARPAV station, typically visibility and
+  pressure, unless you turn that off.
+
+Values taken from a METAR are marked with `source: metar`, so they can always
+be told apart from the ones measured by the ARPAV station.
+
+> [!IMPORTANT]
+Distance matters more than it seems: an aerodrome 60 km away describes the
+general state of the sky well, and local fog or low stratus poorly, which in the
+Po valley is exactly the typical winter situation. The distance of each
+aerodrome is shown in the selection list.
+
+> [!TIP]
+Not every aerodrome reports around the clock: the smaller ones only publish
+during their opening hours, and the list says which ones are reporting at the
+moment. Choosing one is perfectly fine — reports older than 90 minutes are
+ignored, so outside those hours the values simply go back to being missing and
+the night condition falls back to whatever you configured. A nearby aerodrome
+reporting only by day can still be a better choice than a distant one reporting
+always.
+
+> [!NOTE]
+Reports are retrieved from the
+[Aviation Weather Center](https://aviationweather.gov/data/api/) of the US
+National Weather Service, which requires no credentials, and are fetched at most
+once every 10 minutes, since a METAR is issued every 30.
 
 ## Data provenance
 
@@ -130,14 +202,14 @@ attributes:
 
 | Attribute | Description |
 | --------- | ----------- |
-| `source` | Origin of the value: `station`, `air_quality_station`, `sky_brightness_station`, `forecast` or `unknown` |
+| `source` | Origin of the value: `station`, `air_quality_station`, `sky_brightness_station`, `metar`, `forecast` or `unknown` |
 | `source_name` | The reporting station, or the forecast zone |
 | `source_observed_at` | When the value was observed at the origin, which can be well before the last update |
 
 The weather entity exposes the same information for the current condition,
 prefixed with `condition_`, plus `condition_source_rule`: the criterion that
 decided the condition, one of `precipitation`, `visibility`, `wind`,
-`solar_radiation`, `sky_brightness` or `forecast`.
+`solar_radiation`, `sky_brightness`, `cloud_cover` or `forecast`.
 
 > [!TIP]
 `condition_source` is the honest way to tell a measured condition from a

--- a/README.md
+++ b/README.md
@@ -115,6 +115,37 @@ for separately switching between <i>clear</i>, <i>partly cloudy</i> and <i>cloud
 during day and night.
 
 
+## Data provenance
+
+A single weather station in Home Assistant is fed by several distinct ARPAV
+networks: the [meteogram](https://www.arpa.veneto.it/dati-ambientali/dati-in-diretta/meteo-idro-nivo/variabili_meteo)
+network for the observations, the [air quality](https://www.arpa.veneto.it/dati-ambientali/dati-in-diretta/aria/qualita-aria-dati-in-diretta)
+network, the [night sky brightness](https://www.arpa.veneto.it/dati-ambientali/dati-in-diretta/luminosita-del-cielo/brillanza)
+network and the forecast bulletin. They have different locations, different
+sampling intervals and different publishing latencies, and not every value is
+an observation: some are forecasts.
+
+Every entity therefore reports where its value comes from, as extra state
+attributes:
+
+| Attribute | Description |
+| --------- | ----------- |
+| `source` | Origin of the value: `station`, `air_quality_station`, `sky_brightness_station`, `forecast` or `unknown` |
+| `source_name` | The reporting station, or the forecast zone |
+| `source_observed_at` | When the value was observed at the origin, which can be well before the last update |
+
+The weather entity exposes the same information for the current condition,
+prefixed with `condition_`, plus `condition_source_rule`: the criterion that
+decided the condition, one of `precipitation`, `visibility`, `wind`,
+`solar_radiation`, `sky_brightness` or `forecast`.
+
+> [!TIP]
+`condition_source` is the honest way to tell a measured condition from a
+forecast one: for example a `cloudy` state coming from
+`source: station, source_rule: solar_radiation` is measured sunlight, while
+`source: forecast` means the sky could not be measured and the bulletin was
+used instead.
+
 ## Expose raw data
 
 In order to get the raw data for advanced stuff in HA, from the UI go to

--- a/custom_components/arpa_veneto_weather/config_flow.py
+++ b/custom_components/arpa_veneto_weather/config_flow.py
@@ -1,4 +1,6 @@
 """Config flow to configure Arpa Veneto Weather component."""
+import logging
+
 import aiohttp
 import voluptuous as vol
 from homeassistant import config_entries
@@ -27,7 +29,20 @@ from .const import (
     CONF_PM10_STATION,
     CONF_PM25_STATION,
     CONF_OZONE_STATION,
+    CONF_NIGHT_CONDITION,
+    CONF_NIGHT_CONDITION_BRIGHTNESS_OR_FORECAST,
+    CONF_NIGHT_CONDITION_BRIGHTNESS,
+    CONF_NIGHT_CONDITION_METAR,
+    CONF_NIGHT_CONDITION_FORECAST,
+    CONF_NIGHT_CONDITION_UNKNOWN,
+    CONF_OBSERVATIONS,
+    CONF_METAR_STATION,
+    CONF_METAR_FILL_MISSING,
 )
+from . import metar
+from .coordinator import haversine
+
+_LOGGER = logging.getLogger(__name__)
 
 async def fetch_zone_names():
     """Fetch human-readable names for each zonaid."""
@@ -252,6 +267,14 @@ class ArpaVenetoWeatherOptionsFlowHandler(config_entries.OptionsFlow):
         self.pm10_stations, _ = await pm10_stations_response
         self.pm25_stations, _ = await pm25_stations_response
 
+        # Fetch the aerodromes issuing METAR around the station
+        self.metar_stations = await self._async_metar_stations()
+        configured_metar = self.config_entry.options.get(
+            CONF_OBSERVATIONS, {}).get(CONF_METAR_STATION) or "None"
+        if configured_metar != "None" and configured_metar not in self.metar_stations:
+            # keep the current choice selectable even if the list is unavailable
+            self.metar_stations = {configured_metar: configured_metar} | self.metar_stations
+
         return self.async_show_form(
             step_id="init",
             data_schema=vol.Schema(
@@ -286,6 +309,41 @@ class ArpaVenetoWeatherOptionsFlowHandler(config_entries.OptionsFlow):
                             translation_key=CONF_INFER_CONDITION
                         ),
                     ),
+                    vol.Optional(
+                        CONF_NIGHT_CONDITION,
+                        default=self.config_entry.options.get(
+                            CONF_NIGHT_CONDITION) or CONF_NIGHT_CONDITION_BRIGHTNESS_OR_FORECAST
+                    ): selector.SelectSelector(
+                        selector.SelectSelectorConfig(
+                            options=[
+                                CONF_NIGHT_CONDITION_BRIGHTNESS_OR_FORECAST,
+                                CONF_NIGHT_CONDITION_BRIGHTNESS,
+                                CONF_NIGHT_CONDITION_METAR,
+                                CONF_NIGHT_CONDITION_FORECAST,
+                                CONF_NIGHT_CONDITION_UNKNOWN,
+                            ],
+                            mode=selector.SelectSelectorMode.DROPDOWN,
+                            translation_key=CONF_NIGHT_CONDITION
+                        ),
+                    ),
+                    vol.Required(CONF_OBSERVATIONS): section(
+                        # the aerodromes are listed nearest first, with their distance:
+                        # a far away one describes the local sky poorly
+                        vol.Schema(
+                            {
+                                vol.Optional(
+                                    CONF_METAR_STATION,
+                                    default=configured_metar
+                                ): vol.In({"None": "-"} | self.metar_stations),
+                                vol.Optional(
+                                    CONF_METAR_FILL_MISSING,
+                                    default=self.config_entry.options.get(
+                                        CONF_OBSERVATIONS, {}).get(CONF_METAR_FILL_MISSING, True)
+                                ): bool,
+                            }
+                        ),
+                        {"collapsed": True}
+                    ),
                     vol.Required(CONF_AIR_QUALITY): section(
                         # for air stations, populate the list with fetched stations plus a "None" option
                         # also set the default value from existing config or "None" if not set
@@ -313,6 +371,42 @@ class ArpaVenetoWeatherOptionsFlowHandler(config_entries.OptionsFlow):
                 }
             )
         )
+
+    async def _async_station_coordinates(self):
+        """Return the coordinates of the configured station, fetching them if needed."""
+
+        latitude = self.config_entry.data.get("station_latitude")
+        longitude = self.config_entry.data.get("station_longitude")
+        if latitude is not None and longitude is not None:
+            return latitude, longitude
+
+        # entries created before the coordinates were stored
+        _, stations = await fetch_stations()
+        station = stations.get(self.config_entry.data.get("station_id")) or {}
+
+        return station.get("latitudine"), station.get("longitudine")
+
+    async def _async_metar_stations(self):
+        """Return the aerodromes issuing METAR near the station, nearest first."""
+
+        latitude, longitude = await self._async_station_coordinates()
+        if latitude is None or longitude is None:
+            return {}
+
+        try:
+            latitude = float(latitude)
+            longitude = float(longitude)
+            stations = await metar.async_fetch_stations(
+                latitude,
+                longitude,
+                lambda lat, lon: haversine(lat, lon, latitude, longitude),
+            )
+        except (aiohttp.ClientError, TimeoutError, TypeError, ValueError) as err:
+            # an optional source must not prevent the options from being edited
+            _LOGGER.warning("Unable to list the nearby METAR aerodromes: %s", err)
+            return {}
+
+        return {station.icao: station.label for station in stations}
 
     async def async_step_thresholds(self, user_input=None):
         """Manage the thresholds options."""

--- a/custom_components/arpa_veneto_weather/const.py
+++ b/custom_components/arpa_veneto_weather/const.py
@@ -24,6 +24,21 @@ CONF_INFER_CONDITION_NIGHT_CLEAR_THRESHOLD_DEFAULT = 20.5
 CONF_INFER_CONDITION_NIGHT_PARTLY_THRESHOLD = "night_partly_threshold"
 CONF_INFER_CONDITION_NIGHT_PARTLY_THRESHOLD_DEFAULT = 18.5
 
+# Origin of an observation, exposed as the "source" attribute
+SOURCE_STATION = "station"
+SOURCE_AIR_QUALITY_STATION = "air_quality_station"
+SOURCE_BRIGHTNESS_STATION = "sky_brightness_station"
+SOURCE_FORECAST = "forecast"
+SOURCE_UNKNOWN = "unknown"
+
+# Criterion that decided the computed condition, exposed as "source_rule"
+RULE_PRECIPITATION = "precipitation"
+RULE_VISIBILITY = "visibility"
+RULE_WIND = "wind"
+RULE_SOLAR_RADIATION = "solar_radiation"
+RULE_SKY_BRIGHTNESS = "sky_brightness"
+RULE_FORECAST = "forecast"
+
 CONF_AIR_QUALITY = "air_quality"
 CONF_PM10_STATION = "pm10_station"
 CONF_PM25_STATION = "pm25_station"

--- a/custom_components/arpa_veneto_weather/const.py
+++ b/custom_components/arpa_veneto_weather/const.py
@@ -29,6 +29,7 @@ SOURCE_STATION = "station"
 SOURCE_AIR_QUALITY_STATION = "air_quality_station"
 SOURCE_BRIGHTNESS_STATION = "sky_brightness_station"
 SOURCE_FORECAST = "forecast"
+SOURCE_METAR = "metar"
 SOURCE_UNKNOWN = "unknown"
 
 # Criterion that decided the computed condition, exposed as "source_rule"
@@ -37,7 +38,21 @@ RULE_VISIBILITY = "visibility"
 RULE_WIND = "wind"
 RULE_SOLAR_RADIATION = "solar_radiation"
 RULE_SKY_BRIGHTNESS = "sky_brightness"
+RULE_CLOUD_COVER = "cloud_cover"
 RULE_FORECAST = "forecast"
+
+# Additional observations, to complete the ones of the chosen station
+CONF_OBSERVATIONS = "observations"
+CONF_METAR_STATION = "metar_station"
+CONF_METAR_FILL_MISSING = "metar_fill_missing"
+
+# What to report as the current condition while the sun is below the horizon
+CONF_NIGHT_CONDITION = "night_condition"
+CONF_NIGHT_CONDITION_BRIGHTNESS_OR_FORECAST = "night_condition_brightness_or_forecast"
+CONF_NIGHT_CONDITION_BRIGHTNESS = "night_condition_brightness"
+CONF_NIGHT_CONDITION_METAR = "night_condition_metar"
+CONF_NIGHT_CONDITION_FORECAST = "night_condition_forecast"
+CONF_NIGHT_CONDITION_UNKNOWN = "night_condition_unknown"
 
 CONF_AIR_QUALITY = "air_quality"
 CONF_PM10_STATION = "pm10_station"

--- a/custom_components/arpa_veneto_weather/coordinator.py
+++ b/custom_components/arpa_veneto_weather/coordinator.py
@@ -81,19 +81,22 @@ class ArpaVenetoDataUpdateCoordinator(DataUpdateCoordinator):
                     self.latitude, self.longitude, sensor_data, forecast=forecast_data)
             case const.CONF_INFER_CONDITION_FROM_SENSORS_WITH_CUSTOM_THRESHOLDS:
                 opts = self.config_entry.options
-                if opts.get("override_thresholds"):
-                    day_cfg = DayThresholds(
-                        clear_ratio=opts.get(
-                            "day_clear_ratio", const.CONF_INFER_CONDITION_DAY_CLEAR_THRESHOLD_DEFAULT),
-                        partly_ratio=opts.get(
-                            "day_partly_ratio", const.CONF_INFER_CONDITION_DAY_PARTLY_THRESHOLD_DEFAULT),
-                    )
-                    night_cfg = NightThresholds(
-                        cloudy_humidity=opts.get(
-                            "night_cloudy_humidity", const.CONF_INFER_CONDITION_NIGHT_CLEAR_THRESHOLD_DEFAULT),
-                        dark_moon=opts.get(
-                            "night_dark_moon", const.CONF_INFER_CONDITION_NIGHT_PARTLY_THRESHOLD_DEFAULT),
-                    )
+                day_cfg = DayThresholds(
+                    clear=opts.get(
+                        const.CONF_INFER_CONDITION_DAY_CLEAR_THRESHOLD,
+                        const.CONF_INFER_CONDITION_DAY_CLEAR_THRESHOLD_DEFAULT),
+                    partly_cloudy=opts.get(
+                        const.CONF_INFER_CONDITION_DAY_PARTLY_THRESHOLD,
+                        const.CONF_INFER_CONDITION_DAY_PARTLY_THRESHOLD_DEFAULT),
+                )
+                night_cfg = NightThresholds(
+                    clear=opts.get(
+                        const.CONF_INFER_CONDITION_NIGHT_CLEAR_THRESHOLD,
+                        const.CONF_INFER_CONDITION_NIGHT_CLEAR_THRESHOLD_DEFAULT),
+                    partly_cloudy=opts.get(
+                        const.CONF_INFER_CONDITION_NIGHT_PARTLY_THRESHOLD,
+                        const.CONF_INFER_CONDITION_NIGHT_PARTLY_THRESHOLD_DEFAULT),
+                )
 
                 sensor_data["condition"] = await self._compute_condition_from_sensors(
                     self.latitude, self.longitude, sensor_data, day_cfg, night_cfg, forecast=forecast_data)

--- a/custom_components/arpa_veneto_weather/coordinator.py
+++ b/custom_components/arpa_veneto_weather/coordinator.py
@@ -9,11 +9,13 @@ from .const import (
     API_BASE, CARDINAL_DIRECTIONS, DOMAIN
 )
 
+from .provenance import Provenance
 from .thresholds import DayThresholds, NightThresholds
 
 from astral import LocationInfo
 from astral.sun import sun, elevation
 from astral.moon import phase
+from dataclasses import dataclass
 from datetime import datetime, timezone, timedelta, UTC
 from math import radians, cos, sin, asin, sqrt
 
@@ -31,6 +33,16 @@ BRIGHTNESS_MAX_STATIONS = 5
 # readings older than this no longer describe the current sky
 BRIGHTNESS_MAX_AGE_HOURS = 6
 
+
+@dataclass
+class SkyBrightnessReading:
+    """A night sky brightness reading, with the station that observed it."""
+
+    value: float
+    station_name: str | None = None
+    observed_at: str | None = None
+
+
 class ArpaVenetoDataUpdateCoordinator(DataUpdateCoordinator):
     """Data update coordinator for ARPA Veneto."""
 
@@ -38,6 +50,7 @@ class ArpaVenetoDataUpdateCoordinator(DataUpdateCoordinator):
         """Initialize the data update coordinator."""
         self.station_id = config_entry.data.get("station_id")
         self.zone_id = config_entry.data.get("zone_id")
+        self.zone_name = config_entry.data.get("zone_name")
         self.latitude = config_entry.data.get("station_latitude")
         self.longitude = config_entry.data.get("station_longitude")
         self.infer_condition = config_entry.options.get(const.CONF_INFER_CONDITION)
@@ -66,18 +79,36 @@ class ArpaVenetoDataUpdateCoordinator(DataUpdateCoordinator):
         pm25_response = self.fetch_air_quality_data(
             self.pm25_station_id, 'PM2.5') if self.pm25_station_id and self.pm25_station_id != "None" else None
 
-        sensor_data, sensor_data_raw = await sensor_response
+        sensor_data, sensor_data_raw, sources = await sensor_response
         forecast_data, forecast_raw = await forecast_response
-        sensor_data["pm10"] = (await pm10_response).get("MEDIA", None) if pm10_response else None
-        sensor_data["pm25"] = (await pm25_response).get("MEDIA", None) if pm25_response else None
-        sensor_data["ozone"] = (await ozone_response).get("MEDIA", None) if ozone_response else None
+
+        for key, response in (("pm10", pm10_response),
+                              ("pm25", pm25_response),
+                              ("ozone", ozone_response)):
+            latest = await response if response else None
+            sensor_data[key] = latest.get("MEDIA", None) if latest else None
+            if latest:
+                sources[key] = Provenance(
+                    source=const.SOURCE_AIR_QUALITY_STATION,
+                    name=latest.get("STAZIONE"),
+                    observed_at=_arpav_isoformat(latest.get("DATA")),
+                )
+
+        # this one is a forecast, not an observation: it comes from the bulletin
+        nearest_forecast = self._nearest_forecast(datetime.now(), forecast_data)
+        if nearest_forecast:
+            sources["precipitation_probability"] = Provenance(
+                source=const.SOURCE_FORECAST,
+                name=self.zone_name,
+                observed_at=nearest_forecast["datetime"].isoformat(),
+            )
 
         day_cfg = DayThresholds()
         night_cfg = NightThresholds()
         # Determine the current condition based on configuration
         match self.infer_condition:
             case const.CONF_INFER_CONDITION_FROM_SENSORS | None:
-                sensor_data["condition"] = await self._compute_condition_from_sensors(
+                sensor_data["condition"], sources["condition"] = await self._compute_condition_from_sensors(
                     self.latitude, self.longitude, sensor_data, forecast=forecast_data)
             case const.CONF_INFER_CONDITION_FROM_SENSORS_WITH_CUSTOM_THRESHOLDS:
                 opts = self.config_entry.options
@@ -98,7 +129,7 @@ class ArpaVenetoDataUpdateCoordinator(DataUpdateCoordinator):
                         const.CONF_INFER_CONDITION_NIGHT_PARTLY_THRESHOLD_DEFAULT),
                 )
 
-                sensor_data["condition"] = await self._compute_condition_from_sensors(
+                sensor_data["condition"], sources["condition"] = await self._compute_condition_from_sensors(
                     self.latitude, self.longitude, sensor_data, day_cfg, night_cfg, forecast=forecast_data)
             case _:  # CONF_INFER_CONDITION_DISABLED or any other value
                 pass  # Do not compute condition
@@ -108,6 +139,7 @@ class ArpaVenetoDataUpdateCoordinator(DataUpdateCoordinator):
             "forecast_raw": forecast_raw,
             "sensors": sensor_data,  # Include sensor data like temperature
             "sensors_raw": sensor_data_raw,
+            "sources": sources,  # Where each value comes from, keyed as in "sensors"
         }
 
     async def fetch_station_data(self, station_id):
@@ -136,44 +168,22 @@ class ArpaVenetoDataUpdateCoordinator(DataUpdateCoordinator):
         filtered_data = list(latest_by_type.values())
 
         extracted_data = {}
+        sources = {}
         # Extract temperature, humidity, and other data
         for entry in filtered_data:
             extracted_data["station_name"] = entry.get("nome_stazione")
 
-            tipo = entry.get("tipo")
-            valore = entry.get("valore")
-            # latitudine = entry.get("latitudine")
-            # longitudine = entry.get("longitudine")
+            values = _values_from_observation(entry)
+            extracted_data.update(values)
 
-            if tipo.startswith("TARIA"):
-                extracted_data["temperature"] = float(valore)
-            elif tipo.startswith("UMID"):
-                extracted_data["humidity"] = int(valore)
-            elif tipo == "VISIB":
-                extracted_data["visibility"] = round(int(valore) / 1000, 2)
-            elif tipo == "PRESS":
-                extracted_data["pressure"] = float(valore)
-            elif tipo == "PREC":
-                extracted_data["precipitation"] = float(valore)
-            elif tipo.startswith("DVENTO"):
-                degrees = int(valore)
-                extracted_data["native_wind_bearing"] = degrees
-                extracted_data["wind_bearing"] = CARDINAL_DIRECTIONS[int((degrees + 11.25)/22.5)]
-            elif tipo.startswith("VVENTO"):
-                extracted_data["wind_speed"] = round(float(valore) * 3.6, 2)
-            elif tipo == "RADSOL":
-                # Assuming UV Fraction = 6% => 0.06
-                if (entry.get("unitnm") == "MJ/m2"):
-                    # For MJ/m², the scaling factor is 40 because it includes cumulative energy and time
-                    extracted_data["uv_index"] = round(float(valore) * 0.06 * 40)
-                    extracted_data["ghi"] = round(mj_to_wm2(float(valore), 3600))
-                elif (entry.get("unitnm") == "w/m2"):
-                    # For W/m², the scaling factor is 0.04 because it represents instantaneous power
-                    extracted_data["uv_index"] = round(float(valore) * 0.06 * 0.04)
-                    extracted_data["ghi"] = round(float(valore))
-            elif tipo == "BFOGL":
-                # Leaf wetness, reported as the share of the interval the leaf was wet
-                extracted_data["leaf_wetness"] = float(valore)
+            # each observation carries its own timestamp, so track it per value
+            observed_at = _arpav_isoformat(entry.get("dataora"))
+            for key in values:
+                sources[key] = Provenance(
+                    source=const.SOURCE_STATION,
+                    name=entry.get("nome_stazione"),
+                    observed_at=observed_at,
+                )
 
         # prepare additional precipitation metrics
         # given that
@@ -215,18 +225,30 @@ class ArpaVenetoDataUpdateCoordinator(DataUpdateCoordinator):
             precipitation_cumulative_today = _cumulate_since(precipitation_data, midnight)
 
             # Add these computed metrics to the extracted_data dictionary
-            extracted_data["precipitation_hourly"] = precipitation_hourly
-            extracted_data["precipitation_cumulative_today"] = precipitation_cumulative_today
-            extracted_data["precipitation_cumulative_1h"] = precipitation_cumulative_1h
-            extracted_data["precipitation_cumulative_3h"] = precipitation_cumulative_3h
-            extracted_data["precipitation_cumulative_6h"] = precipitation_cumulative_6h
-            extracted_data["precipitation_cumulative_12h"] = precipitation_cumulative_12h
-            extracted_data["precipitation_cumulative_24h"] = precipitation_cumulative_24h
+            computed = {
+                "precipitation_hourly": precipitation_hourly,
+                "precipitation_cumulative_today": precipitation_cumulative_today,
+                "precipitation_cumulative_1h": precipitation_cumulative_1h,
+                "precipitation_cumulative_3h": precipitation_cumulative_3h,
+                "precipitation_cumulative_6h": precipitation_cumulative_6h,
+                "precipitation_cumulative_12h": precipitation_cumulative_12h,
+                "precipitation_cumulative_24h": precipitation_cumulative_24h,
+            }
+            extracted_data.update(computed)
+
+            # they are aggregates of the station data points, up to the latest one
+            observed_at = _arpav_isoformat(precipitation_data[0].get("dataora"))
+            for key in computed:
+                sources[key] = Provenance(
+                    source=const.SOURCE_STATION,
+                    name=extracted_data.get("station_name"),
+                    observed_at=observed_at,
+                )
 
         extracted_data["last_update"] = datetime.now().isoformat()
         extracted_data["dt"] = dataora
 
-        return extracted_data, filtered_data
+        return extracted_data, filtered_data, sources
 
     async def fetch_air_quality_data(self, station_id, parametro):
         """Fetch air quality data from the station."""
@@ -271,7 +293,8 @@ class ArpaVenetoDataUpdateCoordinator(DataUpdateCoordinator):
         :param day_cfg: the day thresholds configuration
         :param night_cfg: the night thresholds configuration
         :param forecast: assembled forecast entries, used as a night fallback
-        :return: string ["clear-night", "partlycloudy", "cloudy", "unknown"]
+        :return: a tuple with the condition string ["clear-night", "partlycloudy", "cloudy", "unknown"]
+            and the Provenance of the data that decided it
         """
 
         temperature = sensor_data.get("temperature")
@@ -282,27 +305,38 @@ class ArpaVenetoDataUpdateCoordinator(DataUpdateCoordinator):
 
         ghi = sensor_data.get("ghi")
 
+        def measured(rule):
+            """Return the provenance of a condition decided by the station."""
+
+            return Provenance(
+                source=const.SOURCE_STATION,
+                name=sensor_data.get("station_name"),
+                observed_at=_arpav_isoformat(sensor_data.get("dt")),
+                rule=rule,
+            )
+
         # Precipitation overrides everything
         if precipitation is not None and precipitation > 0:
+            rain = measured(const.RULE_PRECIPITATION)
             if temperature is not None:
                 # lowest threshold first, otherwise the second branch is dead code
                 if temperature <= 0:
-                    return "snowy"
+                    return "snowy", rain
                 elif temperature <= 5:
-                    return "snowy-rainy"
+                    return "snowy-rainy", rain
                 if precipitation > 20:
-                    return "pouring"
-            return "rainy"
+                    return "pouring", rain
+            return "rainy", rain
 
         # Visibility overrides wind
         if visibility is not None:
             if visibility < 1:
-                return "fog"
+                return "fog", measured(const.RULE_VISIBILITY)
             if visibility < 2 and humidity and humidity > 99:
-                return "fog"
+                return "fog", measured(const.RULE_VISIBILITY)
 
         if wind_speed and wind_speed > 30:
-            return "windy"
+            return "windy", measured(const.RULE_WIND)
 
         city = LocationInfo(latitude=lat, longitude=lon)
         s = sun(city.observer, date=dt.date(), tzinfo=dt.tzinfo)
@@ -310,14 +344,17 @@ class ArpaVenetoDataUpdateCoordinator(DataUpdateCoordinator):
         is_day = s["sunrise"] <= dt <= s["sunset"]
 
         if is_day:
+            radiation = measured(const.RULE_SOLAR_RADIATION)
+
             if ghi is None:
-                return "unknown"
+                return "unknown", Provenance(source=const.SOURCE_UNKNOWN)
 
             # Sun elevation in degrees
             h_sun = elevation(city.observer, dt)
 
             if h_sun <= 0:
-                return "unknown"  # Sun below horizon (transitions)
+                # Sun below horizon (transitions)
+                return "unknown", Provenance(source=const.SOURCE_UNKNOWN)
 
             # Theoretical maximum irradiance (approximated)
             ghi_clear = 1000 * sin(radians(h_sun))
@@ -327,20 +364,27 @@ class ArpaVenetoDataUpdateCoordinator(DataUpdateCoordinator):
 
             # Empirical thresholds (to be calibrated on ARPA data)
             if ghi_ratio > day_cfg.clear:
-                return "sunny"
+                return "sunny", radiation
             elif ghi_ratio > day_cfg.partly_cloudy:
-                return "partlycloudy"
+                return "partlycloudy", radiation
             else:
                 if wind_speed and wind_speed > 30:
-                    return "windy-variant"
-                return "cloudy"
+                    return "windy-variant", measured(const.RULE_WIND)
+                return "cloudy", radiation
 
         else:
-            sky_brightness = await self.get_night_sky_brightness(lat, lon)
-            if sky_brightness is None:
+            reading = await self.get_night_sky_brightness(lat, lon)
+            if reading is None:
                 # the brightness network is published in daily batches, so at
                 # night there is often no fresh reading: fall back to the bulletin
-                return self._forecast_condition_at(dt, forecast, night=True) or "unknown"
+                return self._forecast_condition(dt, forecast, night=True)
+
+            brightness = Provenance(
+                source=const.SOURCE_BRIGHTNESS_STATION,
+                name=reading.station_name,
+                observed_at=reading.observed_at,
+                rule=const.RULE_SKY_BRIGHTNESS,
+            )
 
             illum = moon_illumination(dt)
             if illum > 50:
@@ -350,17 +394,35 @@ class ArpaVenetoDataUpdateCoordinator(DataUpdateCoordinator):
             else:
                 offset = 0
 
-            if sky_brightness + offset > night_cfg.clear:
-                return "clear-night"
-            elif sky_brightness + offset > night_cfg.partly_cloudy:
-                return "partlycloudy"
+            if reading.value + offset > night_cfg.clear:
+                return "clear-night", brightness
+            elif reading.value + offset > night_cfg.partly_cloudy:
+                return "partlycloudy", brightness
             else:
                 if wind_speed and wind_speed > 30:
-                    return "windy-variant"
-                return "cloudy"
+                    return "windy-variant", measured(const.RULE_WIND)
+                return "cloudy", brightness
 
-    def _forecast_condition_at(self, dt, forecast, night=False):
-        """Return the forecast condition closest to the given datetime, or None."""
+    def _forecast_condition(self, dt, forecast, night=False):
+        """Return the forecast condition closest to a datetime, with its provenance."""
+
+        nearest = self._nearest_forecast(dt, forecast)
+        if nearest is None:
+            return "unknown", Provenance(source=const.SOURCE_UNKNOWN)
+
+        condition = nearest["condition"]
+        if night and condition in ("sunny", "clear"):
+            condition = "clear-night"
+
+        return condition, Provenance(
+            source=const.SOURCE_FORECAST,
+            name=self.zone_name,
+            observed_at=nearest["datetime"].isoformat(),
+            rule=const.RULE_FORECAST,
+        )
+
+    def _nearest_forecast(self, dt, forecast):
+        """Return the forecast entry closest to the given datetime, or None."""
 
         candidates = [
             f for f in (forecast or [])
@@ -372,15 +434,10 @@ class ArpaVenetoDataUpdateCoordinator(DataUpdateCoordinator):
             return None
 
         target = dt.replace(tzinfo=None)
-        nearest = min(candidates, key=lambda f: abs(f["datetime"] - target))
-        condition = nearest["condition"]
-
-        if night and condition in ("sunny", "clear"):
-            return "clear-night"
-        return condition
+        return min(candidates, key=lambda f: abs(f["datetime"] - target))
 
     async def get_night_sky_brightness(self, lat, lon):
-        """Approximate night sky brightness (mag/arcsec²) based on location."""
+        """Return the nearest usable night sky brightness reading, or None."""
 
         url = f"{API_BASE}/meteo_meteogrammi?rete=MGRAMMIBRI&coordcd=20067&orario=0"
         async with aiohttp.ClientSession() as session, session.get(url) as response:
@@ -392,14 +449,15 @@ class ArpaVenetoDataUpdateCoordinator(DataUpdateCoordinator):
         stations = sort_locations_by_distance(data.get("data", []), lat, lon)
 
         for station in stations[:BRIGHTNESS_MAX_STATIONS]:
-            sky_brightness = await self._fetch_station_brightness(station.get("codseqst"))
-            if sky_brightness is not None:
-                return sky_brightness
+            reading = await self._fetch_station_brightness(
+                station.get("codseqst"), station.get("nome_stazione"))
+            if reading is not None:
+                return reading
 
         _LOGGER.debug("No usable sky brightness reading from the nearby stations")
         return None
 
-    async def _fetch_station_brightness(self, codseqst):
+    async def _fetch_station_brightness(self, codseqst, station_name=None):
         """Return the latest usable brightness reading of a station, or None."""
 
         if codseqst is None:
@@ -436,7 +494,72 @@ class ArpaVenetoDataUpdateCoordinator(DataUpdateCoordinator):
         if datetime.now() - reading_dt > timedelta(hours=BRIGHTNESS_MAX_AGE_HOURS):
             return None
 
-        return sky_brightness
+        return SkyBrightnessReading(
+            value=sky_brightness,
+            station_name=station_name or latest.get("nome_stazione"),
+            observed_at=_arpav_isoformat(latest.get("dataora")),
+        )
+
+
+def _values_from_observation(entry):
+    """Map a single meteogram observation to the sensor values it feeds."""
+
+    tipo = entry.get("tipo")
+    valore = entry.get("valore")
+
+    if tipo is None or valore is None:
+        return {}
+
+    if tipo.startswith("TARIA"):
+        return {"temperature": float(valore)}
+    if tipo.startswith("UMID"):
+        return {"humidity": int(valore)}
+    if tipo == "VISIB":
+        return {"visibility": round(int(valore) / 1000, 2)}
+    if tipo == "PRESS":
+        return {"pressure": float(valore)}
+    if tipo == "PREC":
+        return {"precipitation": float(valore)}
+    if tipo.startswith("DVENTO"):
+        degrees = int(valore)
+        return {
+            "native_wind_bearing": degrees,
+            "wind_bearing": CARDINAL_DIRECTIONS[int((degrees + 11.25)/22.5)],
+        }
+    if tipo.startswith("VVENTO"):
+        return {"wind_speed": round(float(valore) * 3.6, 2)}
+    if tipo == "RADSOL":
+        # Assuming UV Fraction = 6% => 0.06
+        if (entry.get("unitnm") == "MJ/m2"):
+            # For MJ/m², the scaling factor is 40 because it includes cumulative energy and time
+            return {
+                "uv_index": round(float(valore) * 0.06 * 40),
+                "ghi": round(mj_to_wm2(float(valore), 3600)),
+            }
+        if (entry.get("unitnm") == "w/m2"):
+            # For W/m², the scaling factor is 0.04 because it represents instantaneous power
+            return {
+                "uv_index": round(float(valore) * 0.06 * 0.04),
+                "ghi": round(float(valore)),
+            }
+        return {}
+    if tipo == "BFOGL":
+        # Leaf wetness, reported as the share of the interval the leaf was wet
+        return {"leaf_wetness": float(valore)}
+
+    return {}
+
+
+def _arpav_isoformat(dataora):
+    """Return an ARPAV timestamp as an ISO string, with its fixed +0100 offset."""
+
+    if not dataora:
+        return None
+
+    try:
+        return datetime.strptime(dataora + " +0100", "%Y-%m-%dT%H:%M:%S %z").isoformat()
+    except (TypeError, ValueError):
+        return dataora
 
 
 def find_nearest_location(locations, target_lat, target_lon):

--- a/custom_components/arpa_veneto_weather/coordinator.py
+++ b/custom_components/arpa_veneto_weather/coordinator.py
@@ -9,13 +9,14 @@ from .const import (
     API_BASE, CARDINAL_DIRECTIONS, DOMAIN
 )
 
+from . import metar
 from .provenance import Provenance
 from .thresholds import DayThresholds, NightThresholds
 
 from astral import LocationInfo
 from astral.sun import sun, elevation
 from astral.moon import phase
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from datetime import datetime, timezone, timedelta, UTC
 from math import radians, cos, sin, asin, sqrt
 
@@ -59,6 +60,15 @@ class ArpaVenetoDataUpdateCoordinator(DataUpdateCoordinator):
         self.pm25_station_id = air_quality.get(const.CONF_PM25_STATION) if air_quality else None
         self.ozone_station_id = air_quality.get(const.CONF_OZONE_STATION) if air_quality else None
 
+        observations = config_entry.options.get(const.CONF_OBSERVATIONS) or {}
+        metar_station = observations.get(const.CONF_METAR_STATION)
+        self.metar_station = metar_station if metar_station not in (None, "None") else None
+        self.metar_fill_missing = observations.get(const.CONF_METAR_FILL_MISSING, True)
+        self.night_condition = (config_entry.options.get(const.CONF_NIGHT_CONDITION)
+                                or const.CONF_NIGHT_CONDITION_BRIGHTNESS_OR_FORECAST)
+        self._metar_observation = None
+        self._metar_fetched_at = None
+
         super().__init__(
             hass,
             _LOGGER,
@@ -94,6 +104,11 @@ class ArpaVenetoDataUpdateCoordinator(DataUpdateCoordinator):
                     observed_at=_arpav_isoformat(latest.get("DATA")),
                 )
 
+        # additional observations, for what the chosen station does not provide
+        metar_observation = await self.async_metar_observation()
+        if metar_observation and self.metar_fill_missing:
+            _fill_missing_values(sensor_data, sources, metar_observation)
+
         # this one is a forecast, not an observation: it comes from the bulletin
         nearest_forecast = self._nearest_forecast(datetime.now(), forecast_data)
         if nearest_forecast:
@@ -109,7 +124,8 @@ class ArpaVenetoDataUpdateCoordinator(DataUpdateCoordinator):
         match self.infer_condition:
             case const.CONF_INFER_CONDITION_FROM_SENSORS | None:
                 sensor_data["condition"], sources["condition"] = await self._compute_condition_from_sensors(
-                    self.latitude, self.longitude, sensor_data, forecast=forecast_data)
+                    self.latitude, self.longitude, sensor_data, forecast=forecast_data,
+                    sources=sources)
             case const.CONF_INFER_CONDITION_FROM_SENSORS_WITH_CUSTOM_THRESHOLDS:
                 opts = self.config_entry.options
                 day_cfg = DayThresholds(
@@ -130,7 +146,8 @@ class ArpaVenetoDataUpdateCoordinator(DataUpdateCoordinator):
                 )
 
                 sensor_data["condition"], sources["condition"] = await self._compute_condition_from_sensors(
-                    self.latitude, self.longitude, sensor_data, day_cfg, night_cfg, forecast=forecast_data)
+                    self.latitude, self.longitude, sensor_data, day_cfg, night_cfg,
+                    forecast=forecast_data, sources=sources)
             case _:  # CONF_INFER_CONDITION_DISABLED or any other value
                 pass  # Do not compute condition
 
@@ -140,7 +157,29 @@ class ArpaVenetoDataUpdateCoordinator(DataUpdateCoordinator):
             "sensors": sensor_data,  # Include sensor data like temperature
             "sensors_raw": sensor_data_raw,
             "sources": sources,  # Where each value comes from, keyed as in "sensors"
+            "metar": metar_observation,  # Additional observations, when configured
         }
+
+    async def async_metar_observation(self):
+        """Return the latest METAR observation, refreshed at most every few minutes."""
+
+        if not self.metar_station:
+            return None
+
+        now = datetime.now(UTC)
+        if (self._metar_fetched_at is None
+                or now - self._metar_fetched_at >= metar.MIN_FETCH_INTERVAL):
+            observation = await metar.async_fetch_observation(self.metar_station)
+            self._metar_fetched_at = now
+            if observation is not None:
+                self._metar_observation = observation
+
+        # aerodromes with limited opening hours stop reporting overnight, and
+        # keeping their last report would describe the sky of hours ago
+        if self._metar_observation is None or not self._metar_observation.is_current:
+            return None
+
+        return self._metar_observation
 
     async def fetch_station_data(self, station_id):
         """Fetch data from the station."""
@@ -268,18 +307,18 @@ class ArpaVenetoDataUpdateCoordinator(DataUpdateCoordinator):
 
         return latest
 
-    async def _compute_condition_from_sensors(self, lat, long, sensor_data, day_cfg=DayThresholds(), night_cfg=NightThresholds(), forecast=None):
+    async def _compute_condition_from_sensors(self, lat, long, sensor_data, day_cfg=DayThresholds(), night_cfg=NightThresholds(), forecast=None, sources=None):
         """Compute the current condition based on sensor data."""
 
         dt = await self._local_dt(sensor_data.get("dt"))
-        return await self.classify_sky(lat, long, dt, sensor_data, day_cfg, night_cfg, forecast)
+        return await self.classify_sky(lat, long, dt, sensor_data, day_cfg, night_cfg, forecast, sources)
 
     async def _local_dt(self, dt_str):
         """Convert a datetime string to a localized datetime object."""
 
         return datetime.strptime(dt_str + " +0100", "%Y-%m-%dT%H:%M:%S %z")
 
-    async def classify_sky(self, lat, lon, dt, sensor_data, day_cfg: DayThresholds, night_cfg: NightThresholds, forecast=None):
+    async def classify_sky(self, lat, lon, dt, sensor_data, day_cfg: DayThresholds, night_cfg: NightThresholds, forecast=None, sources=None):
         """Classifies the sky condition.
 
         Based on:
@@ -293,6 +332,7 @@ class ArpaVenetoDataUpdateCoordinator(DataUpdateCoordinator):
         :param day_cfg: the day thresholds configuration
         :param night_cfg: the night thresholds configuration
         :param forecast: assembled forecast entries, used as a night fallback
+        :param sources: the Provenance of each sensor value, keyed as sensor_data
         :return: a tuple with the condition string ["clear-night", "partlycloudy", "cloudy", "unknown"]
             and the Provenance of the data that decided it
         """
@@ -305,8 +345,13 @@ class ArpaVenetoDataUpdateCoordinator(DataUpdateCoordinator):
 
         ghi = sensor_data.get("ghi")
 
-        def measured(rule):
-            """Return the provenance of a condition decided by the station."""
+        def measured(rule, key):
+            """Return the provenance of the value that decided the condition."""
+
+            provenance = (sources or {}).get(key)
+            if provenance is not None:
+                # the deciding value may well come from an additional source
+                return replace(provenance, rule=rule)
 
             return Provenance(
                 source=const.SOURCE_STATION,
@@ -317,7 +362,7 @@ class ArpaVenetoDataUpdateCoordinator(DataUpdateCoordinator):
 
         # Precipitation overrides everything
         if precipitation is not None and precipitation > 0:
-            rain = measured(const.RULE_PRECIPITATION)
+            rain = measured(const.RULE_PRECIPITATION, "precipitation")
             if temperature is not None:
                 # lowest threshold first, otherwise the second branch is dead code
                 if temperature <= 0:
@@ -331,12 +376,12 @@ class ArpaVenetoDataUpdateCoordinator(DataUpdateCoordinator):
         # Visibility overrides wind
         if visibility is not None:
             if visibility < 1:
-                return "fog", measured(const.RULE_VISIBILITY)
+                return "fog", measured(const.RULE_VISIBILITY, "visibility")
             if visibility < 2 and humidity and humidity > 99:
-                return "fog", measured(const.RULE_VISIBILITY)
+                return "fog", measured(const.RULE_VISIBILITY, "visibility")
 
         if wind_speed and wind_speed > 30:
-            return "windy", measured(const.RULE_WIND)
+            return "windy", measured(const.RULE_WIND, "wind_speed")
 
         city = LocationInfo(latitude=lat, longitude=lon)
         s = sun(city.observer, date=dt.date(), tzinfo=dt.tzinfo)
@@ -344,7 +389,7 @@ class ArpaVenetoDataUpdateCoordinator(DataUpdateCoordinator):
         is_day = s["sunrise"] <= dt <= s["sunset"]
 
         if is_day:
-            radiation = measured(const.RULE_SOLAR_RADIATION)
+            radiation = measured(const.RULE_SOLAR_RADIATION, "ghi")
 
             if ghi is None:
                 return "unknown", Provenance(source=const.SOURCE_UNKNOWN)
@@ -367,41 +412,93 @@ class ArpaVenetoDataUpdateCoordinator(DataUpdateCoordinator):
                 return "sunny", radiation
             elif ghi_ratio > day_cfg.partly_cloudy:
                 return "partlycloudy", radiation
-            else:
-                if wind_speed and wind_speed > 30:
-                    return "windy-variant", measured(const.RULE_WIND)
-                return "cloudy", radiation
+
+            return "cloudy", radiation
 
         else:
-            reading = await self.get_night_sky_brightness(lat, lon)
-            if reading is None:
+            return await self._night_condition(lat, lon, dt, night_cfg, forecast)
+
+    async def _night_condition(self, lat, lon, dt, night_cfg: NightThresholds, forecast=None):
+        """Report the sky while the sun is below the horizon, as configured.
+
+        No source works everywhere: the sky brightness network publishes daily
+        batches, so its readings describe the previous night rather than the
+        current one, and an aerodrome observes the sky in real time but from
+        however far away it happens to be. The choice is therefore left to the
+        user, defaulting to the historical behaviour.
+        """
+
+        match self.night_condition:
+            case const.CONF_NIGHT_CONDITION_UNKNOWN:
+                return "unknown", Provenance(source=const.SOURCE_UNKNOWN)
+
+            case const.CONF_NIGHT_CONDITION_FORECAST:
+                return self._forecast_condition(dt, forecast, night=True)
+
+            case const.CONF_NIGHT_CONDITION_METAR:
+                condition, provenance = await self._metar_condition(is_day=False)
+                if condition is not None:
+                    return condition, provenance
+                # no report available: better a forecast than nothing
+                return self._forecast_condition(dt, forecast, night=True)
+
+            case const.CONF_NIGHT_CONDITION_BRIGHTNESS:
+                condition, provenance = await self._brightness_condition(lat, lon, dt, night_cfg)
+                if condition is not None:
+                    return condition, provenance
+                return "unknown", Provenance(source=const.SOURCE_UNKNOWN)
+
+            case _:  # CONF_NIGHT_CONDITION_BRIGHTNESS_OR_FORECAST, the default
+                condition, provenance = await self._brightness_condition(lat, lon, dt, night_cfg)
+                if condition is not None:
+                    return condition, provenance
                 # the brightness network is published in daily batches, so at
                 # night there is often no fresh reading: fall back to the bulletin
                 return self._forecast_condition(dt, forecast, night=True)
 
-            brightness = Provenance(
-                source=const.SOURCE_BRIGHTNESS_STATION,
-                name=reading.station_name,
-                observed_at=reading.observed_at,
-                rule=const.RULE_SKY_BRIGHTNESS,
-            )
+    async def _brightness_condition(self, lat, lon, dt, night_cfg: NightThresholds):
+        """Report the sky from the night sky brightness, or (None, None)."""
 
-            illum = moon_illumination(dt)
-            if illum > 50:
-                offset = -2
-            elif illum > 10:
-                offset = -1
-            else:
-                offset = 0
+        reading = await self.get_night_sky_brightness(lat, lon)
+        if reading is None:
+            return None, None
 
-            if reading.value + offset > night_cfg.clear:
-                return "clear-night", brightness
-            elif reading.value + offset > night_cfg.partly_cloudy:
-                return "partlycloudy", brightness
-            else:
-                if wind_speed and wind_speed > 30:
-                    return "windy-variant", measured(const.RULE_WIND)
-                return "cloudy", brightness
+        provenance = Provenance(
+            source=const.SOURCE_BRIGHTNESS_STATION,
+            name=reading.station_name,
+            observed_at=reading.observed_at,
+            rule=const.RULE_SKY_BRIGHTNESS,
+        )
+
+        illum = moon_illumination(dt)
+        if illum > 50:
+            offset = -2
+        elif illum > 10:
+            offset = -1
+        else:
+            offset = 0
+
+        if reading.value + offset > night_cfg.clear:
+            return "clear-night", provenance
+        elif reading.value + offset > night_cfg.partly_cloudy:
+            return "partlycloudy", provenance
+
+        return "cloudy", provenance
+
+    async def _metar_condition(self, is_day):
+        """Report the sky from the configured aerodrome, or (None, None)."""
+
+        observation = await self.async_metar_observation()
+        condition = metar.condition(observation, is_day)
+        if condition is None:
+            return None, None
+
+        return condition, Provenance(
+            source=const.SOURCE_METAR,
+            name=observation.name,
+            observed_at=observation.observed_at,
+            rule=const.RULE_CLOUD_COVER,
+        )
 
     def _forecast_condition(self, dt, forecast, night=False):
         """Return the forecast condition closest to a datetime, with its provenance."""
@@ -548,6 +645,21 @@ def _values_from_observation(entry):
         return {"leaf_wetness": float(valore)}
 
     return {}
+
+
+def _fill_missing_values(sensor_data, sources, observation):
+    """Complete the station data with the values it does not provide."""
+
+    for key, value in observation.values.items():
+        if value is None or sensor_data.get(key) is not None:
+            continue
+
+        sensor_data[key] = value
+        sources[key] = Provenance(
+            source=const.SOURCE_METAR,
+            name=observation.name,
+            observed_at=observation.observed_at,
+        )
 
 
 def _arpav_isoformat(dataora):

--- a/custom_components/arpa_veneto_weather/metar.py
+++ b/custom_components/arpa_veneto_weather/metar.py
@@ -1,0 +1,356 @@
+"""Optional METAR observations, used to complete the ARPAV data.
+
+ARPAV weather stations do not observe the state of the sky, and several of them
+publish neither visibility nor pressure. Aerodromes do: a METAR is an actual
+observation, issued every 30 minutes with a few minutes of latency, and it
+reports cloud cover layer by layer.
+
+Reports come from the Aviation Weather Center of the US National Weather
+Service (https://aviationweather.gov/data/api/), which serves them as JSON
+with cloud layers already decoded and needs no credentials.
+
+The trade-off is distance: an aerodrome tens of kilometres away describes the
+synoptic sky well and local fog or low stratus badly, so choosing a station is
+left to the user, who knows how far it is and what the local weather does.
+"""
+
+import logging
+from dataclasses import dataclass, field
+from datetime import UTC, datetime, timedelta
+from math import exp
+
+import aiohttp
+
+from .const import CARDINAL_DIRECTIONS
+
+_LOGGER = logging.getLogger(__name__)
+
+API_BASE = "https://aviationweather.gov/api/data"
+
+# a METAR is issued every 30 minutes, so polling faster is pointless
+MIN_FETCH_INTERVAL = timedelta(minutes=10)
+
+# aerodromes with limited opening hours simply stop reporting, and a report from
+# hours ago no longer describes the current weather
+MAX_OBSERVATION_AGE = timedelta(minutes=90)
+
+# how far around the station to look for aerodromes, in degrees
+SEARCH_RANGE_DEGREES = 1.5
+
+# cloud cover as eighths of the sky, as reported by the layer abbreviations
+CLOUD_COVER_OKTAS = {
+    "SKC": 0,   # sky clear
+    "CLR": 0,   # clear below 12000 ft
+    "NCD": 0,   # no cloud detected
+    "NSC": 0,   # no significant cloud
+    "CAVOK": 0,  # ceiling and visibility OK
+    "FEW": 2,   # 1 to 2 eighths
+    "SCT": 4,   # 3 to 4 eighths, scattered
+    "BKN": 6,   # 5 to 7 eighths, broken
+    "OVC": 8,   # 8 eighths, overcast
+    "OVX": 8,   # sky obscured
+    "VV": 8,    # vertical visibility only
+}
+
+# a clear sky is reported explicitly, so an empty layer list means "not observed"
+CLEAR_SKY_TOKENS = ("CAVOK", "NCD", "NSC", "SKC", "CLR")
+
+KNOTS_TO_KMH = 1.852
+STATUTE_MILES_TO_KM = 1.609344
+
+
+@dataclass
+class MetarStation:
+    """An aerodrome issuing METAR reports."""
+
+    icao: str
+    name: str
+    latitude: float
+    longitude: float
+    distance_km: float
+    reporting: bool = True
+    """Whether a report is available right now, which for some aerodromes
+    depends on their opening hours."""
+
+    @property
+    def label(self) -> str:
+        """Return a description including the distance from the weather station."""
+
+        label = f"{self.icao} - {self.name} ({self.distance_km:.1f} km)"
+        if not self.reporting:
+            label += " - not reporting right now"
+
+        return label
+
+
+@dataclass
+class MetarObservation:
+    """The observations of a single METAR report."""
+
+    icao: str
+    observed_at: str | None = None
+    cloud_coverage: int | None = None
+    weather: str | None = None
+    values: dict = field(default_factory=dict)
+    raw: str | None = None
+
+    @property
+    def name(self) -> str:
+        """Return the origin to expose as the source of these values."""
+
+        return f"METAR {self.icao}"
+
+    @property
+    def is_current(self) -> bool:
+        """Return whether the report is recent enough to describe the weather now."""
+
+        if not self.observed_at:
+            return False
+
+        try:
+            observed_at = datetime.fromisoformat(self.observed_at)
+        except (TypeError, ValueError):
+            return False
+
+        if observed_at.tzinfo is None:
+            observed_at = observed_at.replace(tzinfo=UTC)
+
+        return datetime.now(UTC) - observed_at <= MAX_OBSERVATION_AGE
+
+
+async def async_fetch_stations(latitude, longitude, distance_of):
+    """Return the aerodromes issuing METAR around a location, nearest first.
+
+    Some aerodromes are registered as METAR sites but publish nothing, and
+    others only during their opening hours, so the ones reporting at the moment
+    come first.
+
+    :param distance_of: callable returning the distance in km from the station
+    """
+
+    span = SEARCH_RANGE_DEGREES
+    bbox = f"{latitude - span},{longitude - span},{latitude + span},{longitude + span}"
+    url = f"{API_BASE}/stationinfo?bbox={bbox}&format=json"
+
+    async with aiohttp.ClientSession() as session, session.get(url) as response:
+        response.raise_for_status()
+        data = await response.json()
+
+    stations = []
+    for entry in data:
+        icao = entry.get("icaoId")
+        latitudine = entry.get("lat")
+        longitudine = entry.get("lon")
+        # some entries only issue TAF forecasts, or carry no usable position
+        if not icao or latitudine is None or longitudine is None:
+            continue
+        if "METAR" not in (entry.get("siteType") or []):
+            continue
+
+        stations.append(MetarStation(
+            icao=icao,
+            name=entry.get("site") or icao,
+            latitude=latitudine,
+            longitude=longitudine,
+            distance_km=distance_of(latitudine, longitudine),
+        ))
+
+    reporting = await _async_reporting_icaos([station.icao for station in stations])
+    for station in stations:
+        station.reporting = station.icao in reporting
+
+    # the nearest aerodrome is of no use while it is not publishing anything
+    return sorted(stations, key=lambda station: (not station.reporting, station.distance_km))
+
+
+async def _async_reporting_icaos(icaos):
+    """Return which of the given aerodromes have a report available right now."""
+
+    if not icaos:
+        return set()
+
+    url = f"{API_BASE}/metar?ids={','.join(icaos)}&format=json"
+
+    try:
+        async with aiohttp.ClientSession() as session, session.get(url) as response:
+            response.raise_for_status()
+            data = await response.json()
+    except (aiohttp.ClientError, TimeoutError) as err:
+        # without this detail the list is still usable, just less informative
+        _LOGGER.debug("Unable to tell which aerodromes are reporting: %s", err)
+        return set(icaos)
+
+    return {report.get("icaoId") for report in data}
+
+
+async def async_fetch_observation(icao):
+    """Return the latest METAR observation of an aerodrome, or None."""
+
+    url = f"{API_BASE}/metar?ids={icao}&format=json"
+
+    try:
+        async with aiohttp.ClientSession() as session, session.get(url) as response:
+            response.raise_for_status()
+            data = await response.json()
+    except (aiohttp.ClientError, TimeoutError) as err:
+        # an optional data source must never take the whole update down
+        _LOGGER.warning("Unable to fetch the METAR report of %s: %s", icao, err)
+        return None
+
+    if not data:
+        _LOGGER.debug("No METAR report available for %s", icao)
+        return None
+
+    return _parse_observation(data[0])
+
+
+def _parse_observation(report):
+    """Turn a METAR report into the observations it provides."""
+
+    raw = report.get("rawOb") or ""
+    values = {}
+
+    visibility = _visibility_km(report.get("visib"))
+    if visibility is not None:
+        values["visibility"] = visibility
+
+    for key, value in (("pressure", report.get("altim")),
+                       ("temperature", report.get("temp"))):
+        if value is not None:
+            values[key] = float(value)
+
+    humidity = _relative_humidity(report.get("temp"), report.get("dewp"))
+    if humidity is not None:
+        values["humidity"] = humidity
+
+    wind_speed = report.get("wspd")
+    if wind_speed is not None:
+        values["wind_speed"] = round(float(wind_speed) * KNOTS_TO_KMH, 2)
+
+    bearing = report.get("wdir")
+    # a variable wind direction is reported as VRB and has no bearing
+    if isinstance(bearing, (int, float)):
+        values["native_wind_bearing"] = int(bearing)
+        values["wind_bearing"] = CARDINAL_DIRECTIONS[int((int(bearing) + 11.25) / 22.5)]
+
+    return MetarObservation(
+        icao=report.get("icaoId"),
+        observed_at=_observed_at(report),
+        cloud_coverage=_cloud_coverage(report.get("clouds"), raw),
+        weather=report.get("wxString"),
+        values=values,
+        raw=raw or None,
+    )
+
+
+def condition(observation, is_day):
+    """Return the Home Assistant condition described by a METAR, or None.
+
+    Present weather wins over cloud cover: a broken sky raining is rainy.
+    """
+
+    if observation is None:
+        return None
+
+    weather = (observation.weather or "").upper()
+
+    if "TS" in weather:
+        return "lightning-rainy" if any(code in weather for code in ("RA", "DZ", "SN")) else "lightning"
+    if "SN" in weather or "SG" in weather:
+        return "snowy-rainy" if any(code in weather for code in ("RA", "DZ")) else "snowy"
+    if "FZRA" in weather or "FZDZ" in weather or "PL" in weather or "IC" in weather:
+        return "snowy-rainy"
+    if "GR" in weather or "GS" in weather:
+        return "hail"
+    if "RA" in weather or "DZ" in weather:
+        return "pouring" if weather.startswith("+") else "rainy"
+    if "FG" in weather or "BR" in weather or "HZ" in weather or "FU" in weather:
+        return "fog"
+
+    coverage = observation.cloud_coverage
+    if coverage is None:
+        return None
+
+    if coverage <= 12:  # nothing, or at most a couple of eighths
+        return "sunny" if is_day else "clear-night"
+    if coverage <= 50:  # few to scattered
+        return "partlycloudy"
+    return "cloudy"
+
+
+def _cloud_coverage(layers, raw):
+    """Return the total cloud cover as a percentage, or None if not observed."""
+
+    oktas = [
+        CLOUD_COVER_OKTAS[cover]
+        for layer in (layers or [])
+        if (cover := (layer.get("cover") or "").upper()) in CLOUD_COVER_OKTAS
+    ]
+
+    if oktas:
+        # the total cover is the one of the most covering layer
+        return round(max(oktas) * 100 / 8)
+
+    # with no layer reported, only an explicit "clear" token means a clear sky
+    if any(token in raw.upper() for token in CLEAR_SKY_TOKENS):
+        return 0
+
+    return None
+
+
+def _visibility_km(visibility):
+    """Return the reported visibility in km, or None.
+
+    METAR visibility is reported in statute miles, and a trailing "+" marks a
+    lower bound ("6+" means 6 miles or more), which is kept as the value.
+    """
+
+    if visibility is None:
+        return None
+
+    try:
+        miles = float(str(visibility).replace("+", "").strip())
+    except (TypeError, ValueError):
+        return None
+
+    return round(miles * STATUTE_MILES_TO_KM, 2)
+
+
+def _relative_humidity(temperature, dew_point):
+    """Return the relative humidity from temperature and dew point, or None."""
+
+    if temperature is None or dew_point is None:
+        return None
+
+    # Magnus-Tetens approximation
+    a, b = 17.625, 243.04
+    try:
+        temperature = float(temperature)
+        dew_point = float(dew_point)
+    except (TypeError, ValueError):
+        return None
+
+    saturation = exp(a * dew_point / (b + dew_point) - a * temperature / (b + temperature))
+
+    return min(100, max(0, round(100 * saturation)))
+
+
+def _observed_at(report):
+    """Return the observation time of a report as an ISO string, or None."""
+
+    report_time = report.get("reportTime")
+    if report_time:
+        # e.g. "2026-08-18T11:00:00.000Z"
+        try:
+            return datetime.fromisoformat(report_time.replace("Z", "+00:00")).isoformat()
+        except (AttributeError, TypeError, ValueError):
+            pass
+
+    observation_time = report.get("obsTime")
+    if observation_time:
+        try:
+            return datetime.fromtimestamp(int(observation_time)).astimezone().isoformat()
+        except (TypeError, ValueError, OSError):
+            pass
+
+    return None

--- a/custom_components/arpa_veneto_weather/provenance.py
+++ b/custom_components/arpa_veneto_weather/provenance.py
@@ -1,0 +1,38 @@
+"""Provenance of the observations feeding the entities.
+
+A single weather station in Home Assistant is fed by several ARPAV networks
+(meteogram, air quality, night sky brightness) and by the forecast bulletin,
+each with its own location and its own publishing latency. Every value
+therefore carries the origin it was observed by, exposed as extra state
+attributes, so that a measurement can be told apart from a forecast.
+"""
+
+from dataclasses import dataclass
+
+
+@dataclass
+class Provenance:
+    """Where a single observation comes from."""
+
+    source: str
+    """Machine readable origin, one of the SOURCE_* constants."""
+
+    name: str | None = None
+    """Human readable origin, typically the name of the reporting station."""
+
+    observed_at: str | None = None
+    """Timestamp of the observation, as reported by the origin."""
+
+    rule: str | None = None
+    """For the computed condition only: the criterion that decided it."""
+
+    def as_attributes(self) -> dict:
+        """Return the provenance as extra state attributes, skipping empty fields."""
+
+        attributes = {
+            "source": self.source,
+            "source_name": self.name,
+            "source_observed_at": self.observed_at,
+            "source_rule": self.rule,
+        }
+        return {key: value for key, value in attributes.items() if value is not None}

--- a/custom_components/arpa_veneto_weather/sensor.py
+++ b/custom_components/arpa_veneto_weather/sensor.py
@@ -71,11 +71,18 @@ class ArpaVenetoSensor(CoordinatorEntity[DataUpdateCoordinator], SensorEntity):
 
     @property
     def extra_state_attributes(self):
-        """Return additional attributes."""
-        return {
+        """Return additional attributes, including where the value comes from."""
+        attributes = {
             "station_id": self.station_id,
             "last_update": self.coordinator.data["sensors"].get("last_update"),
         }
+
+        # the entities of a single station are fed by different networks
+        provenance = self.coordinator.data.get("sources", {}).get(self.sensor_type)
+        if provenance:
+            attributes.update(provenance.as_attributes())
+
+        return attributes
 
     async def async_update(self):
         """Update the sensor state."""

--- a/custom_components/arpa_veneto_weather/translations/en.json
+++ b/custom_components/arpa_veneto_weather/translations/en.json
@@ -35,6 +35,18 @@
         "step": {
             "init": {
                 "sections": {
+                    "observations": {
+                        "name": "Additional observations",
+                        "description": "ARPAV stations do not observe the state of the sky, and some of them report neither visibility nor pressure. The aerodromes below, listed nearest first, publish a METAR observation every 30 minutes and can complete the missing data. Keep in mind that a distant aerodrome describes the general sky well and local fog or low clouds badly.",
+                        "data": {
+                            "metar_station": "Aerodrome issuing METAR",
+                            "metar_fill_missing": "Use it for the data the station does not provide"
+                        },
+                        "data_description": {
+                            "metar_station": "Select the aerodrome to use as an additional observation source",
+                            "metar_fill_missing": "Fill in visibility, pressure and any other value missing from the chosen station"
+                        }
+                    },
                     "air_quality": {
                         "name": "Air quality sensors",
                         "description": "Select the stations to use for air quality data. If you don't want to use air quality data, just leave these options unselected.",
@@ -54,7 +66,8 @@
                     "expose_forecast_json": "Expose JSON extra attribute for internal forecast data",
                     "expose_forecast_raw": "Expose JSON extra attribute for raw original forecast data",
                     "expose_sensors_raw": "Expose extra attributes for raw original sensor data",
-                    "infer_condition": "Compute the current condition"
+                    "infer_condition": "Compute the current condition",
+                    "night_condition": "Current condition at night"
                 }
             },
             "thresholds": {
@@ -73,6 +86,15 @@
                 "infer_condition_from_sensors": "From sensors",
                 "infer_condition_from_sensors_with_custom_thresholds": "From sensors using custom thresholds",
                 "infer_condition_disabled": "Don't compute"
+            }
+        },
+        "night_condition": {
+            "options": {
+                "night_condition_brightness_or_forecast": "Sky brightness, forecast as a fallback",
+                "night_condition_brightness": "Sky brightness only",
+                "night_condition_metar": "METAR observation, forecast as a fallback",
+                "night_condition_forecast": "Forecast bulletin",
+                "night_condition_unknown": "Leave it unknown"
             }
         }
     },

--- a/custom_components/arpa_veneto_weather/translations/it.json
+++ b/custom_components/arpa_veneto_weather/translations/it.json
@@ -33,6 +33,18 @@
         "step": {
             "init": {
                 "sections": {
+                    "observations": {
+                        "name": "Osservazioni aggiuntive",
+                        "description": "Le stazioni ARPAV non osservano lo stato del cielo, e alcune non riportano né visibilità né pressione. Gli aeroporti elencati qui sotto, dal più vicino, pubblicano un'osservazione METAR ogni 30 minuti e possono completare i dati mancanti. Tieni presente che un aeroporto distante descrive bene il cielo in generale e male la nebbia o le nuvole basse locali.",
+                        "data": {
+                            "metar_station": "Aeroporto che pubblica METAR",
+                            "metar_fill_missing": "Usalo per i dati che la stazione non fornisce"
+                        },
+                        "data_description": {
+                            "metar_station": "Scegli l'aeroporto da usare come fonte di osservazione aggiuntiva",
+                            "metar_fill_missing": "Completa visibilità, pressione e ogni altro valore che manca alla stazione scelta"
+                        }
+                    },
                     "air_quality": {
                         "name": "Sensori qualità aria",
                         "description": "Seleziona le stazioni da usare per i dati di qualità dell'aria. Se non vuoi avere questi dati, lascia semplicemente queste opzioni non selezionate.",
@@ -52,7 +64,8 @@
                     "expose_forecast_json": "Esponi attributo JSON aggiuntivo per i dati interni di previsione",
                     "expose_forecast_raw": "Esponi attributo JSON aggiuntivo per i dati originali di previsione",
                     "expose_sensors_raw": "Esponi attributi aggiuntivi per i dati originali di sensore",
-                    "infer_condition": "Calcola la condizione attuale"
+                    "infer_condition": "Calcola la condizione attuale",
+                    "night_condition": "Condizione attuale di notte"
                 }
             },
             "thresholds": {
@@ -71,6 +84,15 @@
                 "infer_condition_from_sensors": "Dai sensori disponibili",
                 "infer_condition_from_sensors_with_custom_thresholds": "Dai sensori usando soglie personalizzate",
                 "infer_condition_disabled": "Non calcolare"
+            }
+        },
+        "night_condition": {
+            "options": {
+                "night_condition_brightness_or_forecast": "Brillanza del cielo, previsione come ripiego",
+                "night_condition_brightness": "Solo brillanza del cielo",
+                "night_condition_metar": "Osservazione METAR, previsione come ripiego",
+                "night_condition_forecast": "Bollettino di previsione",
+                "night_condition_unknown": "Lasciala sconosciuta"
             }
         }
     },

--- a/custom_components/arpa_veneto_weather/weather.py
+++ b/custom_components/arpa_veneto_weather/weather.py
@@ -230,6 +230,12 @@ class ArpaVenetoWeatherEntity(CoordinatorEntity, WeatherEntity):
             "forecast_today_reliability": get_attr(nearest, "forecast_reliability"),
         }
 
+        # tell a measured condition apart from a forecast one
+        provenance = self.coordinator.data.get("sources", {}).get("condition")
+        if provenance:
+            payload.update({f"condition_{key}": value
+                            for key, value in provenance.as_attributes().items()})
+
         if self.expose_forecast_json:
             json_forecast = json.dumps(forecasts, indent=2, cls=DateTimeEncoder)
             payload["forecast"] = json_forecast

--- a/custom_components/arpa_veneto_weather/weather.py
+++ b/custom_components/arpa_veneto_weather/weather.py
@@ -14,6 +14,8 @@ from .const import (
     CONF_EXPOSE_FORECAST_JSON,
     CONF_EXPOSE_FORECAST_RAW,
     CONF_EXPOSE_SENSORS_RAW,
+    CONF_METAR_STATION,
+    CONF_OBSERVATIONS,
     DOMAIN,
     API_BASE,
     KEY_COORDINATOR
@@ -74,6 +76,10 @@ class ArpaVenetoWeatherEntity(CoordinatorEntity, WeatherEntity):
         self._attr_translation_key = 'arpav'
         self._attr_attribution = "Weather data by ARPA Veneto"
 
+        observations = config_entry.options.get(CONF_OBSERVATIONS) or {}
+        if observations.get(CONF_METAR_STATION) not in (None, "None"):
+            self._attr_attribution += ", METAR by NOAA Aviation Weather Center"
+
         self._attr_translation_placeholders = {
             "comune_name": self.comune_name,
             "station_name": self.station_name,
@@ -123,6 +129,12 @@ class ArpaVenetoWeatherEntity(CoordinatorEntity, WeatherEntity):
     def uv_index(self):
         """Return the UV index from the coordinator data."""
         return self.coordinator.data["sensors"].get("uv_index")
+
+    @property
+    def cloud_coverage(self) -> float | None:
+        """Return the cloud coverage, when an additional observation reports it."""
+        observation = self.coordinator.data.get("metar")
+        return observation.cloud_coverage if observation else None
 
     @property
     def native_pressure(self) -> float | None:


### PR DESCRIPTION
Third of the five PRs from #50 (stacked on #55). This is the core of what we discussed: additional observations the user opts into, and the night condition as a configuration choice rather than a built-in policy.

## The night, as a configuration choice

New option, *Current condition at night*:

| Option | Behaviour |
| ------ | --------- |
| **Sky brightness, forecast as a fallback** | **Default — today's behaviour, unchanged** |
| Sky brightness only | Brightness when fresh, otherwise `unknown` |
| METAR observation, forecast as a fallback | Cloud cover observed by the configured aerodrome |
| Forecast bulletin | Always the bulletin |
| Leave it unknown | No condition unless the station measurements decide it |

Existing installations keep the current behaviour: the option defaults to the first row.

## METAR as an additional source

Choosing an aerodrome (opt-in, off by default) gives:

- **`cloud_coverage`** on the weather entity, as a percentage, from the reported layers;
- the **night condition**, if selected above;
- the values the ARPAV station **does not publish** — at Sant'Elena, `visibility` and `pressure` had always been `unknown`, and are now 9.66 km and 1012 hPa with `source: metar`. That is where #55 pays off: filled values are never mistaken for local measurements.

Reports come from the Aviation Weather Center of the US NWS: no credentials, cloud layers already decoded, so no new dependency. Fetched at most once every 10 minutes since a METAR is issued every 30, and a failed fetch keeps the previous report rather than failing the update.

Kept, but not forever: **a report older than 90 minutes is discarded**. Aerodromes with limited opening hours stop reporting overnight, and serving their last one would describe the sky of hours earlier — precisely the problem with the brightness network that started this whole discussion. When there is nothing current, the values go back to missing and the night condition falls back to whatever is configured.

### On picking the aerodrome

The list is fetched around the station coordinates and shows the distance, because that is the trade-off only the user can make: 60 km describes the synoptic sky well and local fog or low stratus badly, which in the Po valley is the typical winter situation.

One thing I did not expect: **plenty of aerodromes registered as METAR sites are not reporting at any given moment**. Around my station 9 or 10 of 26 are silent at a time, so sorting by distance alone can offer one that answers nothing.

It turned out to be intermittence rather than absence, and it matters in both directions. LIPU (Padova, 25 km) returned nothing at 11:20 UTC and was publishing again at 14:00: it reports during its opening hours only. So a nearby aerodrome silent at night can still beat a distant one reporting always — which is why the ones reporting now simply come first, with the others labelled `not reporting right now` rather than filtered out:

```
LIPZ - Venice/Polo Arpt (61.8 km)
LIPS - Istrana (63.3 km)
LIPH - Treviso Arpt (63.6 km)
...
LIPU - Pavdova Arpt (25.2 km) - not reporting right now
```

## Testing

Configured through the real options flow on my instance, so the dynamic list, the section and the reload all went through the normal path.

The night branch cannot wait for nightfall, so I exercised `classify_sky` directly with a night timestamp, for each option:

```
brightness_or_forecast -> clear-night   source=forecast  (brightness stale, as expected)
brightness             -> unknown       source=unknown
metar                  -> partlycloudy  source=metar     rule=cloud_cover
forecast               -> clear-night   source=forecast
unknown                -> unknown       source=unknown
```

The condition mapping was checked against 14 live reports from Italy, Europe and North America, plus constructed cases for fog, snow, thunderstorm, heavy rain, variable wind, an empty payload and a report with no cloud layers (which correctly yields no condition, so the fallback takes over rather than claiming a clear sky).

## Note

Daytime still uses solar radiation: it is a genuinely local measurement, and I would rather not trade it for cloud cover observed 60 km away. If you would like METAR to be selectable for the day as well, that is a small addition on top of this.

Also drops the two `windy-variant` branches: wind above 30 km/h already returns `windy` before the day/night split, so they were unreachable.

