### PR TITLE
feat: optionally archive the night sky brightness as statistics

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,34 @@ forecast one: for example a `cloudy` state coming from
 `source: forecast` means the sky could not be measured and the bulletin was
 used instead.
 
+## Archive of the night sky brightness
+
+The [night sky brightness](https://www.arpa.veneto.it/dati-ambientali/dati-in-diretta/luminosita-del-cielo/brillanza)
+network publishes its readings in a single batch a day, around 09:30 standard
+time, so a night value only becomes available the morning after. That makes it
+unusable to describe the current sky, but it remains a genuine measurement of
+the night that has just passed.
+
+Enabling _Archive the night sky brightness as long-term statistics_ imports
+those readings with their real timestamps, for the three brightness stations
+nearest to the chosen weather station:
+
+- statistics are hourly, with mean, minimum and maximum, in `mag/arcsec²`;
+- they are named `arpa_veneto_weather:sky_brightness_<station>` and can be
+  charted with a `statistics-graph` card;
+- the API exposes about the last 72 hours and they are all re-imported at every
+  run, so a day spent offline recovers by itself, with no duplicates;
+- the import runs at 11:15 local time, after the daily batch, and once at
+  startup. The `arpa_veneto_weather.archive_brightness` service runs it on
+  demand.
+
+> [!NOTE]
+This is entirely separate from the real-time path: no entity and no automation
+is fed by these statistics. They serve to recalibrate the night thresholds on
+the values a given area actually reaches, and to check after the fact what the
+forecast fallback got right. Requires the `recorder` integration, which is
+enabled by default.
+
 ## Expose raw data
 
 In order to get the raw data for advanced stuff in HA, from the UI go to

--- a/custom_components/arpa_veneto_weather/__init__.py
+++ b/custom_components/arpa_veneto_weather/__init__.py
@@ -1,20 +1,34 @@
 """The Arpa Veneto Weather integration."""
 
 import asyncio
+import logging
 from datetime import timedelta
+
+import aiohttp
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.event import async_track_time_change
 
+from .brightness_statistics import async_archive_brightness
 from .coordinator import ArpaVenetoDataUpdateCoordinator
 
 from .const import (
+    CONF_ARCHIVE_BRIGHTNESS,
     DOMAIN,
     KEY_COORDINATOR,
     KEY_UNSUBSCRIBER
 )
 
+_LOGGER = logging.getLogger(__name__)
+
 # Store the configuration in a dict for easy access
 PLATFORMS = ["weather", "sensor"]
+
+# The brightness batch is published around 09:30 standard time: this local hour
+# is past it both in winter and in summer time
+BRIGHTNESS_ARCHIVE_HOUR = 11
+BRIGHTNESS_ARCHIVE_MINUTE = 15
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up ARPA Veneto Weather from a config entry."""
@@ -37,10 +51,42 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     unsub = entry.add_update_listener(options_update_listener)
     hass.data[DOMAIN][entry.entry_id][KEY_UNSUBSCRIBER] = unsub
 
+    if entry.options.get(CONF_ARCHIVE_BRIGHTNESS):
+        _async_schedule_brightness_archive(hass, entry, coordinator)
+
     # Forward the entry to the weather platform
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     return True
+
+
+def _async_schedule_brightness_archive(hass: HomeAssistant, entry: ConfigEntry, coordinator):
+    """Archive the night sky brightness once a day, and on startup."""
+
+    async def archive(_now=None):
+        """Import the readings the API exposes as long-term statistics."""
+        try:
+            imported = await async_archive_brightness(
+                hass, coordinator.latitude, coordinator.longitude)
+        except (aiohttp.ClientError, TimeoutError, HomeAssistantError) as err:
+            # a history archive is never worth failing a setup or an update for
+            _LOGGER.warning("Unable to archive the night sky brightness: %s", err)
+            return
+
+        _LOGGER.debug("Archived %s hourly night sky brightness statistics", imported)
+
+    entry.async_on_unload(
+        async_track_time_change(
+            hass,
+            archive,
+            hour=BRIGHTNESS_ARCHIVE_HOUR,
+            minute=BRIGHTNESS_ARCHIVE_MINUTE,
+            second=0,
+        )
+    )
+
+    # the API exposes about 72 hours, so this recovers the days spent offline
+    entry.async_create_background_task(hass, archive(), f"{DOMAIN}_archive_brightness")
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry):
@@ -66,22 +112,37 @@ async def async_setup(hass, config):
     """Register the service."""
     async def handle_refresh_data(call):
         """Handle the service call to refresh data."""
-        # Access the integration's coordinators, one per configured station
-        entries = hass.data.get(DOMAIN, {})
-        entry_id = call.data.get("entry_id")
-        # without an explicit entry, refresh every configured station
-        entry_ids = [entry_id] if entry_id else list(entries)
+        for coordinator in _called_coordinators(hass, call):
+            await coordinator.async_request_refresh()
 
-        for target in entry_ids:
-            coordinator = entries.get(target, {}).get(KEY_COORDINATOR)
-            if coordinator is not None:
-                await coordinator.async_request_refresh()
+    async def handle_archive_brightness(call):
+        """Handle the service call to archive the night sky brightness."""
+        for coordinator in _called_coordinators(hass, call):
+            imported = await async_archive_brightness(
+                hass, coordinator.latitude, coordinator.longitude)
+            _LOGGER.debug("Archived %s hourly night sky brightness statistics", imported)
 
-    # Register the service
+    # Register the services
     hass.services.async_register(
         DOMAIN, "refresh_data", handle_refresh_data
     )
+    hass.services.async_register(
+        DOMAIN, "archive_brightness", handle_archive_brightness
+    )
     return True
+
+
+def _called_coordinators(hass: HomeAssistant, call):
+    """Return the coordinators a service call is meant for."""
+
+    # one coordinator per configured station
+    entries = hass.data.get(DOMAIN, {})
+    entry_id = call.data.get("entry_id")
+    # without an explicit entry, the call is meant for every station
+    entry_ids = [entry_id] if entry_id else list(entries)
+
+    return [coordinator for target in entry_ids
+            if (coordinator := entries.get(target, {}).get(KEY_COORDINATOR)) is not None]
 
 async def options_update_listener(hass: HomeAssistant, config: ConfigEntry):
     """Handle options update."""

--- a/custom_components/arpa_veneto_weather/brightness_statistics.py
+++ b/custom_components/arpa_veneto_weather/brightness_statistics.py
@@ -1,0 +1,143 @@
+"""Archive of the ARPAV night sky brightness as long-term statistics.
+
+The brightness network publishes its readings in a single batch a day, around
+09:30 standard time, so a night value only becomes available the morning after:
+it can never describe the current sky, but it is a genuine measurement of the
+night that has just passed.
+
+Its honest use is therefore as history. Home Assistant cannot back-date states,
+but it can import long-term statistics with their real timestamps, so the
+readings are archived as hourly external statistics. The API exposes roughly the
+last 72 hours, which are re-imported every time: writing the same hour twice
+overwrites it, so a missed day recovers by itself.
+
+This is entirely separate from the real-time path: no entity and no automation
+is fed by these statistics. They serve to recalibrate the sky thresholds on the
+values a given area actually reaches, and to check after the fact what the
+forecast fallback got right.
+"""
+
+import logging
+from datetime import UTC, datetime, timedelta, timezone
+
+import aiohttp
+
+from homeassistant.components.recorder.models import StatisticMeanType, StatisticMetaData
+from homeassistant.components.recorder.statistics import async_add_external_statistics
+from homeassistant.util import slugify
+
+from .const import API_BASE, DOMAIN
+from .coordinator import sort_locations_by_distance
+
+_LOGGER = logging.getLogger(__name__)
+
+# ARPAV timestamps carry no offset and are on a fixed +0100 all year round
+ARPAV_TZ = timezone(timedelta(hours=1))
+
+UNIT_OF_MEASUREMENT = "mag/arcsec²"
+
+# how many of the nearest stations to archive
+DEFAULT_STATIONS = 3
+
+# several stations of the network publish nothing at all, so looking only at the
+# nearest ones would archive less than asked
+MAX_STATIONS_TRIED = 6
+
+# an hour described by fewer readings than this is not worth archiving
+MIN_READINGS_PER_HOUR = 3
+
+
+async def async_archive_brightness(hass, latitude, longitude, stations=DEFAULT_STATIONS):
+    """Archive the brightness readings the API exposes, nearest stations first.
+
+    :return: the number of hourly statistics imported
+    """
+
+    if "recorder" not in hass.config.components:
+        _LOGGER.debug("The recorder is not enabled: nothing to archive")
+        return 0
+
+    imported = 0
+    archived = 0
+    async with aiohttp.ClientSession() as session:
+        network = await _fetch(session, f"{API_BASE}/meteo_meteogrammi?rete=MGRAMMIBRI&coordcd=20067&orario=0")
+        nearest = sort_locations_by_distance(network.get("data", []), latitude, longitude)
+
+        for station in nearest[:MAX_STATIONS_TRIED]:
+            if archived >= stations:
+                break
+
+            codseqst = station.get("codseqst")
+            if codseqst is None:
+                continue
+
+            readings = await _fetch(session, f"{API_BASE}/meteo_brillanza_tabella?codseqst={codseqst}")
+            hourly = _hourly_statistics(readings.get("data", []))
+            if not hourly:
+                _LOGGER.debug("No usable brightness reading from station %s", codseqst)
+                continue
+
+            async_add_external_statistics(hass, _metadata(station), hourly)
+            imported += len(hourly)
+            archived += 1
+
+    return imported
+
+
+async def _fetch(session, url):
+    """Return the JSON payload of an endpoint."""
+
+    async with session.get(url) as response:
+        response.raise_for_status()
+        return await response.json()
+
+
+def _hourly_statistics(readings):
+    """Aggregate the readings of a station into hourly statistics."""
+
+    by_hour = {}
+    for item in readings:
+        try:
+            value = float(item.get("valore"))
+        except (TypeError, ValueError):
+            continue
+
+        # 0 marks a reading with no valid measurement, e.g. during daylight
+        if value <= 0:
+            continue
+
+        try:
+            observed_at = datetime.strptime(item["dataora"], "%Y-%m-%dT%H:%M:%S")
+        except (KeyError, TypeError, ValueError):
+            continue
+
+        hour = observed_at.replace(
+            minute=0, second=0, microsecond=0, tzinfo=ARPAV_TZ).astimezone(UTC)
+        by_hour.setdefault(hour, []).append(value)
+
+    return [
+        {
+            "start": hour,
+            "mean": round(sum(values) / len(values), 2),
+            "min": min(values),
+            "max": max(values),
+        }
+        for hour, values in sorted(by_hour.items())
+        if len(values) >= MIN_READINGS_PER_HOUR
+    ]
+
+
+def _metadata(station):
+    """Return the statistic metadata describing a brightness station."""
+
+    name = station.get("nome_stazione") or str(station.get("codseqst"))
+
+    return StatisticMetaData(
+        mean_type=StatisticMeanType.ARITHMETIC,
+        has_sum=False,
+        name=f"Night sky brightness in {name}",
+        source=DOMAIN,
+        statistic_id=f"{DOMAIN}:sky_brightness_{slugify(name)}",
+        unit_class=None,
+        unit_of_measurement=UNIT_OF_MEASUREMENT,
+    )

--- a/custom_components/arpa_veneto_weather/config_flow.py
+++ b/custom_components/arpa_veneto_weather/config_flow.py
@@ -38,6 +38,7 @@ from .const import (
     CONF_OBSERVATIONS,
     CONF_METAR_STATION,
     CONF_METAR_FILL_MISSING,
+    CONF_ARCHIVE_BRIGHTNESS,
 )
 from . import metar
 from .coordinator import haversine
@@ -309,6 +310,11 @@ class ArpaVenetoWeatherOptionsFlowHandler(config_entries.OptionsFlow):
                             translation_key=CONF_INFER_CONDITION
                         ),
                     ),
+                    vol.Optional(
+                        CONF_ARCHIVE_BRIGHTNESS,
+                        default=self.config_entry.options.get(
+                            CONF_ARCHIVE_BRIGHTNESS) or False
+                    ): bool,
                     vol.Optional(
                         CONF_NIGHT_CONDITION,
                         default=self.config_entry.options.get(

--- a/custom_components/arpa_veneto_weather/const.py
+++ b/custom_components/arpa_veneto_weather/const.py
@@ -46,6 +46,9 @@ CONF_OBSERVATIONS = "observations"
 CONF_METAR_STATION = "metar_station"
 CONF_METAR_FILL_MISSING = "metar_fill_missing"
 
+# Archive of the night sky brightness as long-term statistics
+CONF_ARCHIVE_BRIGHTNESS = "archive_brightness"
+
 # What to report as the current condition while the sun is below the horizon
 CONF_NIGHT_CONDITION = "night_condition"
 CONF_NIGHT_CONDITION_BRIGHTNESS_OR_FORECAST = "night_condition_brightness_or_forecast"

--- a/custom_components/arpa_veneto_weather/manifest.json
+++ b/custom_components/arpa_veneto_weather/manifest.json
@@ -7,6 +7,9 @@
         "aiohttp"
     ],
     "dependencies": [],
+    "after_dependencies": [
+        "recorder"
+    ],
     "codeowners": [
         "@davidecavestro"
     ],

--- a/custom_components/arpa_veneto_weather/services.yaml
+++ b/custom_components/arpa_veneto_weather/services.yaml
@@ -9,3 +9,15 @@ refresh_data:
       selector:
         config_entry:
           integration: arpa_veneto_weather
+
+archive_brightness:
+  name: "Archive night sky brightness"
+  description: "Import the night sky brightness readings the ARPAV API exposes (about the last 72 hours) as long-term statistics"
+  fields:
+    entry_id:
+      name: "Station"
+      description: "The configured station whose nearby brightness stations to archive. Archives for all of them when omitted."
+      required: false
+      selector:
+        config_entry:
+          integration: arpa_veneto_weather

--- a/custom_components/arpa_veneto_weather/translations/en.json
+++ b/custom_components/arpa_veneto_weather/translations/en.json
@@ -67,7 +67,8 @@
                     "expose_forecast_raw": "Expose JSON extra attribute for raw original forecast data",
                     "expose_sensors_raw": "Expose extra attributes for raw original sensor data",
                     "infer_condition": "Compute the current condition",
-                    "night_condition": "Current condition at night"
+                    "night_condition": "Current condition at night",
+                    "archive_brightness": "Archive the night sky brightness as long-term statistics"
                 }
             },
             "thresholds": {

--- a/custom_components/arpa_veneto_weather/translations/it.json
+++ b/custom_components/arpa_veneto_weather/translations/it.json
@@ -65,7 +65,8 @@
                     "expose_forecast_raw": "Esponi attributo JSON aggiuntivo per i dati originali di previsione",
                     "expose_sensors_raw": "Esponi attributi aggiuntivi per i dati originali di sensore",
                     "infer_condition": "Calcola la condizione attuale",
-                    "night_condition": "Condizione attuale di notte"
+                    "night_condition": "Condizione attuale di notte",
+                    "archive_brightness": "Archivia la brillanza del cielo notturno come statistiche a lungo termine"
                 }
             },
             "thresholds": {


### PR DESCRIPTION
Last of the five PRs from #50 (stacked on #57). The optional archive we discussed: `async_import_statistics` made opt-in, as you suggested.

## Why

The brightness readings arrive after the fact — one batch a day, around 09:30 standard time — so they can never describe the current sky. But they *are* real measurements of the night just passed. The honest use is history, and Home Assistant cannot back-date states: long-term statistics are the only thing it accepts with real timestamps.

## What it does

Behind a new option (default **off**):

- hourly external statistics with mean, min and max, in `mag/arcsec²`, for the three brightness stations nearest to the chosen one;
- named `arpa_veneto_weather:sky_brightness_<station>`, chartable with a `statistics-graph` card;
- the ~72 hours the API exposes are re-imported in full at every run. Re-writing an hour overwrites it, so a day spent offline recovers by itself with no duplicates;
- runs at 11:15 local time — past the batch in both winter and summer time — plus once at startup, and on demand through `arpa_veneto_weather.archive_brightness`;
- skips `valore <= 0`, which marks a reading with no valid measurement, and needs at least 3 readings to describe an hour.

Note it uses `async_add_external_statistics`, not `async_import_statistics` as I wrote in #50: the latter is for internal statistics and rejects any `source` other than `recorder`.

Nothing in the real-time path reads these statistics. Guarded on the recorder being loaded, with `after_dependencies` so it is set up first.

## Why it is worth having

This is how I found out the night thresholds are unreachable where I live. Around my station the observed maxima are **20.2** (Rovigo), **19.2** (TESS Padova) and **18.7** (Padova) mag/arcsec², against a default clear-sky threshold of **20.5** — so even with fresh data, `clear-night` would essentially never be returned, and with the moon offset almost everything would land on `cloudy`. That is measurable only after the fact, which is exactly what the archive is for. It also makes it possible to check, a posteriori, how often the bulletin fallback was right.

## Testing

Enabled through the real options flow on my instance. Statistics landed correctly:

```
arpa_veneto_weather:sky_brightness_rovigo       | Night sky brightness in Rovigo      | mag/arcsec²
arpa_veneto_weather:sky_brightness_padova       | Night sky brightness in Padova      | mag/arcsec²
arpa_veneto_weather:sky_brightness_tess_padova  | Night sky brightness in TESS Padova | mag/arcsec²
```

36 to 37 hourly points each, no duplicates after re-running, and the night plateau starts at the right local hour, which confirms the fixed `+0100` offset the API uses.

The first run only archived two stations: the nearest one, Masi at 17.5 km, publishes nothing at all, and it was still counted against the limit. Fixed by trying further stations until three are actually archived — the service call then returned all three, which is what the ids above come from.
