### PR TITLE
fix: report the real daily temperature extremes

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,34 @@ forecast one: for example a `cloudy` state coming from
 `source: forecast` means the sky could not be measured and the bulletin was
 used instead.
 
+## Archive of the night sky brightness
+
+The [night sky brightness](https://www.arpa.veneto.it/dati-ambientali/dati-in-diretta/luminosita-del-cielo/brillanza)
+network publishes its readings in a single batch a day, around 09:30 standard
+time, so a night value only becomes available the morning after. That makes it
+unusable to describe the current sky, but it remains a genuine measurement of
+the night that has just passed.
+
+Enabling _Archive the night sky brightness as long-term statistics_ imports
+those readings with their real timestamps, for the three brightness stations
+nearest to the chosen weather station:
+
+- statistics are hourly, with mean, minimum and maximum, in `mag/arcsec²`;
+- they are named `arpa_veneto_weather:sky_brightness_<station>` and can be
+  charted with a `statistics-graph` card;
+- the API exposes about the last 72 hours and they are all re-imported at every
+  run, so a day spent offline recovers by itself, with no duplicates;
+- the import runs at 11:15 local time, after the daily batch, and once at
+  startup. The `arpa_veneto_weather.archive_brightness` service runs it on
+  demand.
+
+> [!NOTE]
+This is entirely separate from the real-time path: no entity and no automation
+is fed by these statistics. They serve to recalibrate the night thresholds on
+the values a given area actually reaches, and to check after the fact what the
+forecast fallback got right. Requires the `recorder` integration, which is
+enabled by default.
+
 ## Expose raw data
 
 In order to get the raw data for advanced stuff in HA, from the UI go to

--- a/custom_components/arpa_veneto_weather/__init__.py
+++ b/custom_components/arpa_veneto_weather/__init__.py
@@ -1,20 +1,34 @@
 """The Arpa Veneto Weather integration."""
 
 import asyncio
+import logging
 from datetime import timedelta
+
+import aiohttp
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.event import async_track_time_change
 
+from .brightness_statistics import async_archive_brightness
 from .coordinator import ArpaVenetoDataUpdateCoordinator
 
 from .const import (
+    CONF_ARCHIVE_BRIGHTNESS,
     DOMAIN,
     KEY_COORDINATOR,
     KEY_UNSUBSCRIBER
 )
 
+_LOGGER = logging.getLogger(__name__)
+
 # Store the configuration in a dict for easy access
 PLATFORMS = ["weather", "sensor"]
+
+# The brightness batch is published around 09:30 standard time: this local hour
+# is past it both in winter and in summer time
+BRIGHTNESS_ARCHIVE_HOUR = 11
+BRIGHTNESS_ARCHIVE_MINUTE = 15
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up ARPA Veneto Weather from a config entry."""
@@ -37,10 +51,42 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     unsub = entry.add_update_listener(options_update_listener)
     hass.data[DOMAIN][entry.entry_id][KEY_UNSUBSCRIBER] = unsub
 
+    if entry.options.get(CONF_ARCHIVE_BRIGHTNESS):
+        _async_schedule_brightness_archive(hass, entry, coordinator)
+
     # Forward the entry to the weather platform
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     return True
+
+
+def _async_schedule_brightness_archive(hass: HomeAssistant, entry: ConfigEntry, coordinator):
+    """Archive the night sky brightness once a day, and on startup."""
+
+    async def archive(_now=None):
+        """Import the readings the API exposes as long-term statistics."""
+        try:
+            imported = await async_archive_brightness(
+                hass, coordinator.latitude, coordinator.longitude)
+        except (aiohttp.ClientError, TimeoutError, HomeAssistantError) as err:
+            # a history archive is never worth failing a setup or an update for
+            _LOGGER.warning("Unable to archive the night sky brightness: %s", err)
+            return
+
+        _LOGGER.debug("Archived %s hourly night sky brightness statistics", imported)
+
+    entry.async_on_unload(
+        async_track_time_change(
+            hass,
+            archive,
+            hour=BRIGHTNESS_ARCHIVE_HOUR,
+            minute=BRIGHTNESS_ARCHIVE_MINUTE,
+            second=0,
+        )
+    )
+
+    # the API exposes about 72 hours, so this recovers the days spent offline
+    entry.async_create_background_task(hass, archive(), f"{DOMAIN}_archive_brightness")
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry):
@@ -66,22 +112,37 @@ async def async_setup(hass, config):
     """Register the service."""
     async def handle_refresh_data(call):
         """Handle the service call to refresh data."""
-        # Access the integration's coordinators, one per configured station
-        entries = hass.data.get(DOMAIN, {})
-        entry_id = call.data.get("entry_id")
-        # without an explicit entry, refresh every configured station
-        entry_ids = [entry_id] if entry_id else list(entries)
+        for coordinator in _called_coordinators(hass, call):
+            await coordinator.async_request_refresh()
 
-        for target in entry_ids:
-            coordinator = entries.get(target, {}).get(KEY_COORDINATOR)
-            if coordinator is not None:
-                await coordinator.async_request_refresh()
+    async def handle_archive_brightness(call):
+        """Handle the service call to archive the night sky brightness."""
+        for coordinator in _called_coordinators(hass, call):
+            imported = await async_archive_brightness(
+                hass, coordinator.latitude, coordinator.longitude)
+            _LOGGER.debug("Archived %s hourly night sky brightness statistics", imported)
 
-    # Register the service
+    # Register the services
     hass.services.async_register(
         DOMAIN, "refresh_data", handle_refresh_data
     )
+    hass.services.async_register(
+        DOMAIN, "archive_brightness", handle_archive_brightness
+    )
     return True
+
+
+def _called_coordinators(hass: HomeAssistant, call):
+    """Return the coordinators a service call is meant for."""
+
+    # one coordinator per configured station
+    entries = hass.data.get(DOMAIN, {})
+    entry_id = call.data.get("entry_id")
+    # without an explicit entry, the call is meant for every station
+    entry_ids = [entry_id] if entry_id else list(entries)
+
+    return [coordinator for target in entry_ids
+            if (coordinator := entries.get(target, {}).get(KEY_COORDINATOR)) is not None]
 
 async def options_update_listener(hass: HomeAssistant, config: ConfigEntry):
     """Handle options update."""

--- a/custom_components/arpa_veneto_weather/brightness_statistics.py
+++ b/custom_components/arpa_veneto_weather/brightness_statistics.py
@@ -1,0 +1,143 @@
+"""Archive of the ARPAV night sky brightness as long-term statistics.
+
+The brightness network publishes its readings in a single batch a day, around
+09:30 standard time, so a night value only becomes available the morning after:
+it can never describe the current sky, but it is a genuine measurement of the
+night that has just passed.
+
+Its honest use is therefore as history. Home Assistant cannot back-date states,
+but it can import long-term statistics with their real timestamps, so the
+readings are archived as hourly external statistics. The API exposes roughly the
+last 72 hours, which are re-imported every time: writing the same hour twice
+overwrites it, so a missed day recovers by itself.
+
+This is entirely separate from the real-time path: no entity and no automation
+is fed by these statistics. They serve to recalibrate the sky thresholds on the
+values a given area actually reaches, and to check after the fact what the
+forecast fallback got right.
+"""
+
+import logging
+from datetime import UTC, datetime, timedelta, timezone
+
+import aiohttp
+
+from homeassistant.components.recorder.models import StatisticMeanType, StatisticMetaData
+from homeassistant.components.recorder.statistics import async_add_external_statistics
+from homeassistant.util import slugify
+
+from .const import API_BASE, DOMAIN
+from .coordinator import sort_locations_by_distance
+
+_LOGGER = logging.getLogger(__name__)
+
+# ARPAV timestamps carry no offset and are on a fixed +0100 all year round
+ARPAV_TZ = timezone(timedelta(hours=1))
+
+UNIT_OF_MEASUREMENT = "mag/arcsec²"
+
+# how many of the nearest stations to archive
+DEFAULT_STATIONS = 3
+
+# several stations of the network publish nothing at all, so looking only at the
+# nearest ones would archive less than asked
+MAX_STATIONS_TRIED = 6
+
+# an hour described by fewer readings than this is not worth archiving
+MIN_READINGS_PER_HOUR = 3
+
+
+async def async_archive_brightness(hass, latitude, longitude, stations=DEFAULT_STATIONS):
+    """Archive the brightness readings the API exposes, nearest stations first.
+
+    :return: the number of hourly statistics imported
+    """
+
+    if "recorder" not in hass.config.components:
+        _LOGGER.debug("The recorder is not enabled: nothing to archive")
+        return 0
+
+    imported = 0
+    archived = 0
+    async with aiohttp.ClientSession() as session:
+        network = await _fetch(session, f"{API_BASE}/meteo_meteogrammi?rete=MGRAMMIBRI&coordcd=20067&orario=0")
+        nearest = sort_locations_by_distance(network.get("data", []), latitude, longitude)
+
+        for station in nearest[:MAX_STATIONS_TRIED]:
+            if archived >= stations:
+                break
+
+            codseqst = station.get("codseqst")
+            if codseqst is None:
+                continue
+
+            readings = await _fetch(session, f"{API_BASE}/meteo_brillanza_tabella?codseqst={codseqst}")
+            hourly = _hourly_statistics(readings.get("data", []))
+            if not hourly:
+                _LOGGER.debug("No usable brightness reading from station %s", codseqst)
+                continue
+
+            async_add_external_statistics(hass, _metadata(station), hourly)
+            imported += len(hourly)
+            archived += 1
+
+    return imported
+
+
+async def _fetch(session, url):
+    """Return the JSON payload of an endpoint."""
+
+    async with session.get(url) as response:
+        response.raise_for_status()
+        return await response.json()
+
+
+def _hourly_statistics(readings):
+    """Aggregate the readings of a station into hourly statistics."""
+
+    by_hour = {}
+    for item in readings:
+        try:
+            value = float(item.get("valore"))
+        except (TypeError, ValueError):
+            continue
+
+        # 0 marks a reading with no valid measurement, e.g. during daylight
+        if value <= 0:
+            continue
+
+        try:
+            observed_at = datetime.strptime(item["dataora"], "%Y-%m-%dT%H:%M:%S")
+        except (KeyError, TypeError, ValueError):
+            continue
+
+        hour = observed_at.replace(
+            minute=0, second=0, microsecond=0, tzinfo=ARPAV_TZ).astimezone(UTC)
+        by_hour.setdefault(hour, []).append(value)
+
+    return [
+        {
+            "start": hour,
+            "mean": round(sum(values) / len(values), 2),
+            "min": min(values),
+            "max": max(values),
+        }
+        for hour, values in sorted(by_hour.items())
+        if len(values) >= MIN_READINGS_PER_HOUR
+    ]
+
+
+def _metadata(station):
+    """Return the statistic metadata describing a brightness station."""
+
+    name = station.get("nome_stazione") or str(station.get("codseqst"))
+
+    return StatisticMetaData(
+        mean_type=StatisticMeanType.ARITHMETIC,
+        has_sum=False,
+        name=f"Night sky brightness in {name}",
+        source=DOMAIN,
+        statistic_id=f"{DOMAIN}:sky_brightness_{slugify(name)}",
+        unit_class=None,
+        unit_of_measurement=UNIT_OF_MEASUREMENT,
+    )

--- a/custom_components/arpa_veneto_weather/config_flow.py
+++ b/custom_components/arpa_veneto_weather/config_flow.py
@@ -38,6 +38,7 @@ from .const import (
     CONF_OBSERVATIONS,
     CONF_METAR_STATION,
     CONF_METAR_FILL_MISSING,
+    CONF_ARCHIVE_BRIGHTNESS,
 )
 from . import metar
 from .coordinator import haversine
@@ -309,6 +310,11 @@ class ArpaVenetoWeatherOptionsFlowHandler(config_entries.OptionsFlow):
                             translation_key=CONF_INFER_CONDITION
                         ),
                     ),
+                    vol.Optional(
+                        CONF_ARCHIVE_BRIGHTNESS,
+                        default=self.config_entry.options.get(
+                            CONF_ARCHIVE_BRIGHTNESS) or False
+                    ): bool,
                     vol.Optional(
                         CONF_NIGHT_CONDITION,
                         default=self.config_entry.options.get(

--- a/custom_components/arpa_veneto_weather/const.py
+++ b/custom_components/arpa_veneto_weather/const.py
@@ -46,6 +46,9 @@ CONF_OBSERVATIONS = "observations"
 CONF_METAR_STATION = "metar_station"
 CONF_METAR_FILL_MISSING = "metar_fill_missing"
 
+# Archive of the night sky brightness as long-term statistics
+CONF_ARCHIVE_BRIGHTNESS = "archive_brightness"
+
 # What to report as the current condition while the sun is below the horizon
 CONF_NIGHT_CONDITION = "night_condition"
 CONF_NIGHT_CONDITION_BRIGHTNESS_OR_FORECAST = "night_condition_brightness_or_forecast"

--- a/custom_components/arpa_veneto_weather/coordinator.py
+++ b/custom_components/arpa_veneto_weather/coordinator.py
@@ -192,12 +192,16 @@ class ArpaVenetoDataUpdateCoordinator(DataUpdateCoordinator):
         # Dictionary to store the max-time item per type
         latest_by_type = {}
         precipitation_data = []
+        temperature_data = []
 
         for item in data.get("data", []):
             t = item["tipo"]
             # Collect all precipitation data points
             if t == "PREC":
                 precipitation_data.append(item)
+            # Collect all temperature data points
+            if t.startswith("TARIA"):
+                temperature_data.append(item)
             # Keep only the latest item per type
             if t not in latest_by_type or item["dataora"] > latest_by_type[t]["dataora"]:
                 latest_by_type[t] = item
@@ -283,6 +287,12 @@ class ArpaVenetoDataUpdateCoordinator(DataUpdateCoordinator):
                     name=extracted_data.get("station_name"),
                     observed_at=observed_at,
                 )
+
+        # the bulletin drops the half-day that has already elapsed, so the only
+        # source left for the extremes of the current day is the station itself
+        extremes = _measured_temperature_extremes(temperature_data)
+        if extremes:
+            extracted_data["measured_temperature_extremes"] = extremes
 
         extracted_data["last_update"] = datetime.now().isoformat()
         extracted_data["dt"] = dataora
@@ -660,6 +670,33 @@ def _fill_missing_values(sensor_data, sources, observation):
             name=observation.name,
             observed_at=observation.observed_at,
         )
+
+
+def _measured_temperature_extremes(temperature_data):
+    """Return the extremes measured on the last day the station reported.
+
+    Both the readings and the bulletin are dated by ARPAV, so the day is taken
+    as reported rather than converted, and the two can be matched directly.
+    """
+
+    values_by_day = {}
+    for item in temperature_data:
+        try:
+            value = float(item.get("valore"))
+        except (TypeError, ValueError):
+            continue
+
+        day = (item.get("dataora") or "")[:10]
+        if day:
+            values_by_day.setdefault(day, []).append(value)
+
+    if not values_by_day:
+        return None
+
+    day = max(values_by_day)
+    values = values_by_day[day]
+
+    return {"date": day, "min": min(values), "max": max(values)}
 
 
 def _arpav_isoformat(dataora):

--- a/custom_components/arpa_veneto_weather/manifest.json
+++ b/custom_components/arpa_veneto_weather/manifest.json
@@ -7,6 +7,9 @@
         "aiohttp"
     ],
     "dependencies": [],
+    "after_dependencies": [
+        "recorder"
+    ],
     "codeowners": [
         "@davidecavestro"
     ],

--- a/custom_components/arpa_veneto_weather/services.yaml
+++ b/custom_components/arpa_veneto_weather/services.yaml
@@ -9,3 +9,15 @@ refresh_data:
       selector:
         config_entry:
           integration: arpa_veneto_weather
+
+archive_brightness:
+  name: "Archive night sky brightness"
+  description: "Import the night sky brightness readings the ARPAV API exposes (about the last 72 hours) as long-term statistics"
+  fields:
+    entry_id:
+      name: "Station"
+      description: "The configured station whose nearby brightness stations to archive. Archives for all of them when omitted."
+      required: false
+      selector:
+        config_entry:
+          integration: arpa_veneto_weather

--- a/custom_components/arpa_veneto_weather/translations/en.json
+++ b/custom_components/arpa_veneto_weather/translations/en.json
@@ -67,7 +67,8 @@
                     "expose_forecast_raw": "Expose JSON extra attribute for raw original forecast data",
                     "expose_sensors_raw": "Expose extra attributes for raw original sensor data",
                     "infer_condition": "Compute the current condition",
-                    "night_condition": "Current condition at night"
+                    "night_condition": "Current condition at night",
+                    "archive_brightness": "Archive the night sky brightness as long-term statistics"
                 }
             },
             "thresholds": {

--- a/custom_components/arpa_veneto_weather/translations/it.json
+++ b/custom_components/arpa_veneto_weather/translations/it.json
@@ -65,7 +65,8 @@
                     "expose_forecast_raw": "Esponi attributo JSON aggiuntivo per i dati originali di previsione",
                     "expose_sensors_raw": "Esponi attributi aggiuntivi per i dati originali di sensore",
                     "infer_condition": "Calcola la condizione attuale",
-                    "night_condition": "Condizione attuale di notte"
+                    "night_condition": "Condizione attuale di notte",
+                    "archive_brightness": "Archivia la brillanza del cielo notturno come statistiche a lungo termine"
                 }
             },
             "thresholds": {

--- a/custom_components/arpa_veneto_weather/weather.py
+++ b/custom_components/arpa_veneto_weather/weather.py
@@ -164,6 +164,10 @@ class ArpaVenetoWeatherEntity(CoordinatorEntity, WeatherEntity):
     def _forecasts(self):
         return self.coordinator.data.get("forecast", [])
 
+    def _measured_extremes(self):
+        """Return the temperature extremes measured on the day the station last reported."""
+        return self.coordinator.data["sensors"].get("measured_temperature_extremes") or {}
+
     async def async_forecast_twice_daily(self) -> list[Forecast] | None:
         """Return the twice-daily forecast."""
         forecasts = self._forecasts()
@@ -194,19 +198,28 @@ class ArpaVenetoWeatherEntity(CoordinatorEntity, WeatherEntity):
                 # Take the first daytime entry for the date
                 selected_entry = daytime_entries[0].copy()
 
-                # Calculate temperatures, considering native_templow if available
+                # every half-day reports a temperature range, so the extremes of
+                # the day are the extremes of those ranges, not of their midpoints
                 temperatures = [
-                    (e["native_temperature"] + e["native_templow"]) / 2
-                    if "native_templow" in e
-                    else e["native_temperature"]
+                    temperature
                     for e in entries
-                    if "native_temperature" in e
+                    for temperature in (e.get("native_temperature"), e.get("native_templow"))
+                    if temperature is not None
                 ]
+
+                # the bulletin stops reporting the half-day that has elapsed, so
+                # for the current day the hours already gone are only known as
+                # measurements: without them today's low would be the low of the
+                # afternoon, well above the actual minimum of the night
+                measured = self._measured_extremes()
+                if measured.get("date") == str(date):
+                    temperatures += [measured["min"], measured["max"]]
                 # Calculate max temperature and min temperature for the date
-                selected_entry["native_temperature"] = max(temperatures)
+                if temperatures:
+                    selected_entry["native_temperature"] = max(temperatures)
                 if len(temperatures) > 1:
                     selected_entry["native_templow"] = min(temperatures)
-                elif "native_templow" in selected_entry:  # no hightly forecast -> no min
+                elif "native_templow" in selected_entry:  # no range at all -> no min
                     del selected_entry["native_templow"]
 
                 # Replace datetime with the date as string


### PR DESCRIPTION
Sixth PR, stacked on #58, unrelated to the sky condition — spotted because the more-info dialog showed today as `33 °C / 33 °C`.

## Two problems

**1. The extremes were computed on the midpoints.** Each half-day bulletin entry carries a temperature *range*, and the aggregation collapsed it to its midpoint before taking max and min:

```python
temperatures = [
    (e["native_temperature"] + e["native_templow"]) / 2 if "native_templow" in e
    else e["native_temperature"]
    for e in entries if "native_temperature" in e
]
selected_entry["native_temperature"] = max(temperatures)   # max of the midpoints
selected_entry["native_templow"] = min(temperatures)       # min of the midpoints
```

So both bounds were pulled inwards by half a range, every day: with the bulletin reporting 20-22 at night and 34-36 during the day, tomorrow came out as **35/21** instead of 36/20.

**2. The bulletin drops the half-day that has elapsed.** From early afternoon, `bollettini_meteo_simboli_en` returns only the afternoon entry for the current day:

```
2026-08-18  afternoon/evening  32/34    <- the only entry left for today
2026-08-19  night/morning      20/22
2026-08-19  afternoon/evening  34/36
```

With a single midpoint left, the high became 33 — a value the bulletin never mentions — and `native_templow` was deleted altogether, which is what makes the frontend render `33 °C / 33 °C`.

Taking the extremes fixes the 33, but the low would then be **32**, the low of the *afternoon*, which has nothing to do with the minimum of the day: the station measured **19.0 °C at 02:00** this morning.

## The fix

Take the extremes of the reported ranges, and for the current day take the ones the station has already measured into account as well.

Those measurements need no extra call: the meteogram payload the coordinator already downloads carries about 2.5 days of readings (369 points for my station, 82 of them from today). They are dated by ARPAV exactly like the bulletin, so the day can be matched as reported, with no timezone conversion in between.

Result on the same data:

| Date | Bulletin | Before | After |
| ---- | -------- | ------ | ----- |
| 18/08 | afternoon 32-34, morning no longer published | 33 / — → `33/33` | **34 / 19** |
| 19/08 | night 20-22, day 34-36 | 35 / 21 | **36 / 20** |
| 20/08 | night 19-21, day 34-36 | 35 / 20 | **36 / 19** |

Today reads 34/19: the afternoon high still to come, and the minimum actually recorded during the night.

Also guards the maximum against a day with no temperature at all: `max()` on an empty sequence raises `ValueError`, which was reachable whenever a date had a daytime entry but no temperature (`tempmiss`).

## Side note

While checking today's values I noticed the two bulletin endpoints disagree with each other, at the same emission time (`2026-08-18T13:00:00`): for 20/08 afternoon, `bollettini_meteo_giornate` says `32/34` while `bollettini_meteo_simboli_en` — the one this integration uses — says `34/36`. Nothing to do with this PR, but worth knowing if a user ever reports a two-degree difference against the ARPAV website.
