### PR TITLE
feat: let the day condition come from an aerodrome too

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Once you have configured a station, you can control some options from ⚙ (its _
 - **Expose extra attributes for raw original sensor data**: Expose as sensors the data obtaining from the remote api call
 - **Compute the current condition**: Expose the weather state as computed from available metrics
 - **Choose stations providing air-quality data**: Since the set of [stations differs](https://www.arpa.veneto.it/dati-ambientali/dati-in-diretta/aria/qualita-aria-dati-in-diretta) between PM10, PM2.5 and Ozone, the user can choose a specific station for each of them. 
+- **Current condition during the day**: Choose which source describes the sky while the sun is above the horizon
 - **Current condition at night**: Choose which source describes the sky while the sun is below the horizon
 - **Additional observations**: Optionally choose an aerodrome publishing METAR reports, to observe the sky and to complete the data the chosen station does not provide
 
@@ -116,11 +117,30 @@ using custom thresholds</b></i> to set custom thresholds
 for separately switching between <i>clear</i>, <i>partly cloudy</i> and <i>cloudy</i>
 during day and night.
 
+### The current condition during the day
+
+Solar radiation is measured by the station itself, so where it is available the
+daytime sky is inferred from a local, near real-time measurement, and that stays
+the default. It is not available everywhere though: **92 of the 223 stations of
+the MGRAMMI network carry no pyranometer**, and for those the daytime condition
+would be `unknown` all day long, every day. The sun very low over the horizon is
+the same problem for a shorter while, since the ratio between the measured and
+the expected irradiance means little around sunrise and sunset.
+
+The choice is therefore left to the user, under _Current condition during the
+day_:
+
+| Option | Behaviour |
+| ------ | --------- |
+| _Solar radiation only_ | The default, and the historical behaviour: use the irradiance ratio, and leave the condition unknown when the station measures no radiation |
+| _Solar radiation, METAR observation as a fallback_ | Use the irradiance ratio when available, otherwise the cloud cover observed by the configured aerodrome. Both are observations, so no forecast is ever served |
+| _METAR observation, forecast as a fallback_ | Always use the aerodrome, and the bulletin when no report is available: for a station whose nearest aerodrome is closer, or more representative, than its own pyranometer |
+| _Forecast bulletin_ | Always use the bulletin |
+| _Leave it unknown_ | Report no condition unless the station measurements alone decide it (rain, fog, wind) |
+
 ### The current condition at night
 
-Daylight is measured by the station itself, so the daytime sky is inferred from
-a local, near real-time observation. The night is the hard part, because no
-single source works everywhere:
+The night is the harder part, because no single source works everywhere:
 
 - the **night sky brightness** network publishes its readings in a single daily
   batch (around 09:30, standard time), so at night the latest reading normally
@@ -159,7 +179,8 @@ Under _Additional observations_ you can select one, from the list of aerodromes
 around the station, **sorted by distance**. When configured, it provides:
 
 - the **cloud coverage** of the weather entity, as a percentage of the sky;
-- the **current condition at night**, if you selected the METAR option above;
+- the **current condition**, day or night, if you selected one of the METAR
+  options above;
 - any value **missing** from the chosen ARPAV station, typically visibility and
   pressure, unless you turn that off.
 

--- a/custom_components/arpa_veneto_weather/config_flow.py
+++ b/custom_components/arpa_veneto_weather/config_flow.py
@@ -29,6 +29,12 @@ from .const import (
     CONF_PM10_STATION,
     CONF_PM25_STATION,
     CONF_OZONE_STATION,
+    CONF_DAY_CONDITION,
+    CONF_DAY_CONDITION_RADIATION,
+    CONF_DAY_CONDITION_RADIATION_OR_METAR,
+    CONF_DAY_CONDITION_METAR,
+    CONF_DAY_CONDITION_FORECAST,
+    CONF_DAY_CONDITION_UNKNOWN,
     CONF_NIGHT_CONDITION,
     CONF_NIGHT_CONDITION_BRIGHTNESS_OR_FORECAST,
     CONF_NIGHT_CONDITION_BRIGHTNESS,
@@ -315,6 +321,23 @@ class ArpaVenetoWeatherOptionsFlowHandler(config_entries.OptionsFlow):
                         default=self.config_entry.options.get(
                             CONF_ARCHIVE_BRIGHTNESS) or False
                     ): bool,
+                    vol.Optional(
+                        CONF_DAY_CONDITION,
+                        default=self.config_entry.options.get(
+                            CONF_DAY_CONDITION) or CONF_DAY_CONDITION_RADIATION
+                    ): selector.SelectSelector(
+                        selector.SelectSelectorConfig(
+                            options=[
+                                CONF_DAY_CONDITION_RADIATION,
+                                CONF_DAY_CONDITION_RADIATION_OR_METAR,
+                                CONF_DAY_CONDITION_METAR,
+                                CONF_DAY_CONDITION_FORECAST,
+                                CONF_DAY_CONDITION_UNKNOWN,
+                            ],
+                            mode=selector.SelectSelectorMode.DROPDOWN,
+                            translation_key=CONF_DAY_CONDITION
+                        ),
+                    ),
                     vol.Optional(
                         CONF_NIGHT_CONDITION,
                         default=self.config_entry.options.get(

--- a/custom_components/arpa_veneto_weather/const.py
+++ b/custom_components/arpa_veneto_weather/const.py
@@ -49,6 +49,14 @@ CONF_METAR_FILL_MISSING = "metar_fill_missing"
 # Archive of the night sky brightness as long-term statistics
 CONF_ARCHIVE_BRIGHTNESS = "archive_brightness"
 
+# What to report as the current condition while the sun is above the horizon
+CONF_DAY_CONDITION = "day_condition"
+CONF_DAY_CONDITION_RADIATION = "day_condition_radiation"
+CONF_DAY_CONDITION_RADIATION_OR_METAR = "day_condition_radiation_or_metar"
+CONF_DAY_CONDITION_METAR = "day_condition_metar"
+CONF_DAY_CONDITION_FORECAST = "day_condition_forecast"
+CONF_DAY_CONDITION_UNKNOWN = "day_condition_unknown"
+
 # What to report as the current condition while the sun is below the horizon
 CONF_NIGHT_CONDITION = "night_condition"
 CONF_NIGHT_CONDITION_BRIGHTNESS_OR_FORECAST = "night_condition_brightness_or_forecast"

--- a/custom_components/arpa_veneto_weather/coordinator.py
+++ b/custom_components/arpa_veneto_weather/coordinator.py
@@ -64,6 +64,8 @@ class ArpaVenetoDataUpdateCoordinator(DataUpdateCoordinator):
         metar_station = observations.get(const.CONF_METAR_STATION)
         self.metar_station = metar_station if metar_station not in (None, "None") else None
         self.metar_fill_missing = observations.get(const.CONF_METAR_FILL_MISSING, True)
+        self.day_condition = (config_entry.options.get(const.CONF_DAY_CONDITION)
+                              or const.CONF_DAY_CONDITION_RADIATION)
         self.night_condition = (config_entry.options.get(const.CONF_NIGHT_CONDITION)
                                 or const.CONF_NIGHT_CONDITION_BRIGHTNESS_OR_FORECAST)
         self._metar_observation = None
@@ -399,34 +401,79 @@ class ArpaVenetoDataUpdateCoordinator(DataUpdateCoordinator):
         is_day = s["sunrise"] <= dt <= s["sunset"]
 
         if is_day:
-            radiation = measured(const.RULE_SOLAR_RADIATION, "ghi")
-
-            if ghi is None:
-                return "unknown", Provenance(source=const.SOURCE_UNKNOWN)
-
-            # Sun elevation in degrees
-            h_sun = elevation(city.observer, dt)
-
-            if h_sun <= 0:
-                # Sun below horizon (transitions)
-                return "unknown", Provenance(source=const.SOURCE_UNKNOWN)
-
-            # Theoretical maximum irradiance (approximated)
-            ghi_clear = 1000 * sin(radians(h_sun))
-
-            # Normalization
-            ghi_ratio = ghi / ghi_clear if ghi_clear > 0 else 0
-
-            # Empirical thresholds (to be calibrated on ARPA data)
-            if ghi_ratio > day_cfg.clear:
-                return "sunny", radiation
-            elif ghi_ratio > day_cfg.partly_cloudy:
-                return "partlycloudy", radiation
-
-            return "cloudy", radiation
+            return await self._day_condition(city, dt, ghi, day_cfg, forecast, measured)
 
         else:
             return await self._night_condition(lat, lon, dt, night_cfg, forecast)
+
+    async def _day_condition(self, city, dt, ghi, day_cfg: DayThresholds, forecast, measured):
+        """Report the sky while the sun is above the horizon, as configured.
+
+        Solar radiation is a local measurement and stays the default, but not
+        every station carries a pyranometer: where it does not, the day has no
+        observed condition at all, and an aerodrome is the only one left.
+        """
+
+        match self.day_condition:
+            case const.CONF_DAY_CONDITION_UNKNOWN:
+                return "unknown", Provenance(source=const.SOURCE_UNKNOWN)
+
+            case const.CONF_DAY_CONDITION_FORECAST:
+                return self._forecast_condition(dt, forecast)
+
+            case const.CONF_DAY_CONDITION_METAR:
+                condition, provenance = await self._metar_condition(is_day=True)
+                if condition is not None:
+                    return condition, provenance
+                # no report available: better a forecast than nothing
+                return self._forecast_condition(dt, forecast)
+
+            case const.CONF_DAY_CONDITION_RADIATION_OR_METAR:
+                condition, provenance = self._radiation_condition(city, dt, ghi, day_cfg, measured)
+                if condition is not None:
+                    return condition, provenance
+                # no pyranometer, or the sun too low for the ratio to mean
+                # anything: the aerodrome observes the sky either way
+                condition, provenance = await self._metar_condition(is_day=True)
+                if condition is not None:
+                    return condition, provenance
+                # measured sources only: no forecast is served here
+                return "unknown", Provenance(source=const.SOURCE_UNKNOWN)
+
+            case _:  # CONF_DAY_CONDITION_RADIATION, the default
+                condition, provenance = self._radiation_condition(city, dt, ghi, day_cfg, measured)
+                if condition is not None:
+                    return condition, provenance
+                return "unknown", Provenance(source=const.SOURCE_UNKNOWN)
+
+    def _radiation_condition(self, city, dt, ghi, day_cfg: DayThresholds, measured):
+        """Report the sky from the incident solar radiation, or (None, None)."""
+
+        if ghi is None:
+            return None, None
+
+        # Sun elevation in degrees
+        h_sun = elevation(city.observer, dt)
+
+        if h_sun <= 0:
+            # Sun below horizon (transitions)
+            return None, None
+
+        radiation = measured(const.RULE_SOLAR_RADIATION, "ghi")
+
+        # Theoretical maximum irradiance (approximated)
+        ghi_clear = 1000 * sin(radians(h_sun))
+
+        # Normalization
+        ghi_ratio = ghi / ghi_clear if ghi_clear > 0 else 0
+
+        # Empirical thresholds (to be calibrated on ARPA data)
+        if ghi_ratio > day_cfg.clear:
+            return "sunny", radiation
+        elif ghi_ratio > day_cfg.partly_cloudy:
+            return "partlycloudy", radiation
+
+        return "cloudy", radiation
 
     async def _night_condition(self, lat, lon, dt, night_cfg: NightThresholds, forecast=None):
         """Report the sky while the sun is below the horizon, as configured.

--- a/custom_components/arpa_veneto_weather/translations/en.json
+++ b/custom_components/arpa_veneto_weather/translations/en.json
@@ -67,6 +67,7 @@
                     "expose_forecast_raw": "Expose JSON extra attribute for raw original forecast data",
                     "expose_sensors_raw": "Expose extra attributes for raw original sensor data",
                     "infer_condition": "Compute the current condition",
+                    "day_condition": "Current condition during the day",
                     "night_condition": "Current condition at night",
                     "archive_brightness": "Archive the night sky brightness as long-term statistics"
                 }
@@ -87,6 +88,15 @@
                 "infer_condition_from_sensors": "From sensors",
                 "infer_condition_from_sensors_with_custom_thresholds": "From sensors using custom thresholds",
                 "infer_condition_disabled": "Don't compute"
+            }
+        },
+        "day_condition": {
+            "options": {
+                "day_condition_radiation": "Solar radiation only",
+                "day_condition_radiation_or_metar": "Solar radiation, METAR observation as a fallback",
+                "day_condition_metar": "METAR observation, forecast as a fallback",
+                "day_condition_forecast": "Forecast bulletin",
+                "day_condition_unknown": "Leave it unknown"
             }
         },
         "night_condition": {

--- a/custom_components/arpa_veneto_weather/translations/it.json
+++ b/custom_components/arpa_veneto_weather/translations/it.json
@@ -65,6 +65,7 @@
                     "expose_forecast_raw": "Esponi attributo JSON aggiuntivo per i dati originali di previsione",
                     "expose_sensors_raw": "Esponi attributi aggiuntivi per i dati originali di sensore",
                     "infer_condition": "Calcola la condizione attuale",
+                    "day_condition": "Condizione attuale di giorno",
                     "night_condition": "Condizione attuale di notte",
                     "archive_brightness": "Archivia la brillanza del cielo notturno come statistiche a lungo termine"
                 }
@@ -85,6 +86,15 @@
                 "infer_condition_from_sensors": "Dai sensori disponibili",
                 "infer_condition_from_sensors_with_custom_thresholds": "Dai sensori usando soglie personalizzate",
                 "infer_condition_disabled": "Non calcolare"
+            }
+        },
+        "day_condition": {
+            "options": {
+                "day_condition_radiation": "Solo radiazione solare",
+                "day_condition_radiation_or_metar": "Radiazione solare, osservazione METAR come ripiego",
+                "day_condition_metar": "Osservazione METAR, previsione come ripiego",
+                "day_condition_forecast": "Bollettino di previsione",
+                "day_condition_unknown": "Lasciala sconosciuta"
             }
         },
         "night_condition": {


### PR DESCRIPTION
Answering your question on #50: the use case is wider than a user whose nearby aerodrome is more reliable than the ARPAV station — although that one exists too, and this covers it.

**Not every station measures solar radiation.** I queried `meteo_meteogrammi_tabella` for all 223 MGRAMMI stations (2026-08-19):

| Sensor | Stations |
| ------ | -------- |
| `TARIA*` | 223 |
| `PREC` | 190 |
| `RADSOL` | **131** |
| `PRESS` | 15 |
| `VISIB` | 11 |

**92 stations out of 223 carry no pyranometer.** For those, the day branch hits `if ghi is None: return "unknown"` and stops there: unlike the night one, the day has no fallback of its own, so their condition is `unknown` from sunrise to sunset, every day. The night is actually better served than the day for 41% of the network.

Two smaller gaps close with the same change:

- `h_sun <= 0` between astronomical sunrise/sunset and a positive elevation returns `unknown` at every twilight, even with a pyranometer;
- irradiance says how much light arrives, not what is in the way: a METAR carries present weather (`FG`, `TS`, `RA`), and with visibility reported by only 11 stations, daytime fog is otherwise invisible to us.

## What this does

`day_condition`, mirroring `night_condition`, **defaulting to the current behaviour**:

| Option | Behaviour |
| ------ | --------- |
| _Solar radiation only_ | The default and the historical behaviour: irradiance ratio, `unknown` when there is no radiation to read |
| _Solar radiation, METAR observation as a fallback_ | Irradiance when available, otherwise the observed cloud cover. Both are observations: no forecast is ever served here, on purpose |
| _METAR observation, forecast as a fallback_ | Always the aerodrome — your use case |
| _Forecast bulletin_ | Always the bulletin |
| _Leave it unknown_ | Only the station measurements decide (rain, fog, wind) |

The day branch of `classify_sky` is extracted into `_day_condition()` / `_radiation_condition()`, symmetric to the night ones. `_metar_condition(is_day=True)` and `metar.condition()` already handled the day, so no METAR code changes.

Running on my instance since this morning, both branches exercised through the real options flow: `condition_source: metar` + `rule: cloud_cover` with _METAR observation_, back to `station` + `solar_radiation` with _Solar radiation, METAR as a fallback_ (my station does have a pyranometer).